### PR TITLE
Set header new framework

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,7 +2,7 @@ workspace(name = "envoy_filter_example")
 
 local_repository(
     name = "envoy",
-    path = "{ENVOY_SRCDIR}",
+    path = "/home/ubuntu/envoy-filter-example/envoy",
 )
 
 load("@envoy//bazel:api_binding.bzl", "envoy_api_binding")

--- a/http-filter-example/BUILD
+++ b/http-filter-example/BUILD
@@ -26,6 +26,7 @@ envoy_cc_library(
     repository = "@envoy",
     deps = [
         ":pkg_cc_proto",
+        ":http_header_processor_lib",
         "@envoy//source/extensions/filters/http/common:pass_through_filter_lib",
     ],
 )
@@ -37,6 +38,17 @@ envoy_cc_library(
     deps = [
         ":http_filter_lib",
         "@envoy//envoy/server:filter_config_interface",
+    ],
+)
+
+envoy_cc_library(
+    name = "http_header_processor_lib",
+    srcs = ["header_processor.cc"],
+    hdrs = ["header_processor.h"],
+    repository = "@envoy",
+    deps = [
+        ":pkg_cc_proto",
+        "@envoy//source/extensions/filters/http/common:pass_through_filter_lib",
     ],
 )
 

--- a/http-filter-example/BUILD
+++ b/http-filter-example/BUILD
@@ -27,6 +27,7 @@ envoy_cc_library(
     deps = [
         ":pkg_cc_proto",
         ":http_header_processor_lib",
+        ":http_header_processor_utils_lib",
         "@envoy//source/extensions/filters/http/common:pass_through_filter_lib",
         "@envoy//source/common/common:utility_lib",
         "@envoy//source/common/common:minimal_logger_lib",
@@ -46,7 +47,19 @@ envoy_cc_library(
 envoy_cc_library(
     name = "http_header_processor_lib",
     srcs = ["header_processor.cc"],
-    hdrs = ["header_processor.h"],
+    hdrs = [ "header_processor.h"],
+    repository = "@envoy",
+    deps = [
+        ":pkg_cc_proto",
+        ":http_header_processor_utils_lib",
+        "@envoy//source/extensions/filters/http/common:pass_through_filter_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "http_header_processor_utils_lib",
+    srcs = ["utility.cc"],
+    hdrs = ["utility.h",],
     repository = "@envoy",
     deps = [
         ":pkg_cc_proto",

--- a/http-filter-example/BUILD
+++ b/http-filter-example/BUILD
@@ -62,7 +62,6 @@ envoy_cc_library(
     hdrs = ["utility.h",],
     repository = "@envoy",
     deps = [
-        ":pkg_cc_proto",
         "@envoy//source/extensions/filters/http/common:pass_through_filter_lib",
     ],
 )

--- a/http-filter-example/envoy-sample-config.yaml
+++ b/http-filter-example/envoy-sample-config.yaml
@@ -45,8 +45,8 @@ static_resources:
             typed_config:
               "@type": type.googleapis.com/sample.Decoder
               key: header-processing
-              val: "http-request set-header x-forwarded-proto https\n http-request set-header mock_key mock_val1 mock_val2"
-              extra: "123456" # experiment with an additional value
+              val: "http-request set-header x-forwarded-proto https\n 
+                    http-request set-header mock_key mock_val1 mock_val2"
           - name: envoy.filters.http.router
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/http-filter-example/envoy-sample-config.yaml
+++ b/http-filter-example/envoy-sample-config.yaml
@@ -45,7 +45,7 @@ static_resources:
             typed_config:
               "@type": type.googleapis.com/sample.Decoder
               key: header-processing
-              val: "http-request set-header x-forwarded-proto https"
+              val: "http-request set-header x-forwarded-proto https\n http-request set-header mock_key mock_val1 mock_val2"
               extra: "123456" # experiment with an additional value
           - name: envoy.filters.http.router
             typed_config:

--- a/http-filter-example/envoy-sample-config.yaml
+++ b/http-filter-example/envoy-sample-config.yaml
@@ -45,8 +45,9 @@ static_resources:
             typed_config:
               "@type": type.googleapis.com/sample.Decoder
               key: header-processing
-              val: "http-request set-header x-forwarded-proto https\n
-                    http-request set-header mock_key mock_val1 mock_val2"
+              val: |
+                  http-request set-header x-forwarded-proto https
+                  http-request set-header mock_key mock_val1 mock_val2
           - name: envoy.filters.http.router
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/http-filter-example/envoy-sample-config.yaml
+++ b/http-filter-example/envoy-sample-config.yaml
@@ -45,7 +45,7 @@ static_resources:
             typed_config:
               "@type": type.googleapis.com/sample.Decoder
               key: header-processing
-              val: "http-request set-header x-forwarded-proto https\n 
+              val: "http-request set-header x-forwarded-proto https\n
                     http-request set-header mock_key mock_val1 mock_val2"
           - name: envoy.filters.http.router
             typed_config:

--- a/http-filter-example/envoy-sample-config.yaml
+++ b/http-filter-example/envoy-sample-config.yaml
@@ -45,7 +45,7 @@ static_resources:
             typed_config:
               "@type": type.googleapis.com/sample.Decoder
               key: header-processing
-              val: "set-header x-forwarded-proto https"
+              val: "http-request set-header x-forwarded-proto https"
               extra: "123456" # experiment with an additional value
           - name: envoy.filters.http.router
             typed_config:

--- a/http-filter-example/header_processor.cc
+++ b/http-filter-example/header_processor.cc
@@ -2,64 +2,59 @@
 
 namespace Envoy {
 namespace Http {
-    ConditionProcessor::ConditionProcessor(std::string& condition_expression) {
-        parseCondition(condition_expression);
+    
+    bool AclProcessor::evaluateAcl(absl::string_view acl_expression) {
+        int temp = 1;
+        if (acl_expression.length() > 0 || temp)
+            return true;
+        return true;
     }
 
-    bool ConditionProcessor::evaluateCondition() {
-        // do map lookup
-        // map[name] -> ConditionProcessor
-
-        isTrue_ = 1;
-        return isTrue_;
+    bool ConditionProcessor::evaluateCondition(absl::string_view condition_expression) {
+        // split condition_expression into each acl, send to acl processor
+        // take conjunction and possibly negation of each acl and return the result
+        return true;
     }
 
-    int ConditionProcessor::parseCondition(std::string& condition_expression) {
-        // return immediately if condition has been evaluated
-        // else evaluate and add to map
-        return 0;
-    }
-
-
-    SetHeaderProcessor::SetHeaderProcessor(bool isRequest, std::string& set_header_expression) {
+    SetHeaderProcessor::SetHeaderProcessor(bool isRequest, absl::string_view set_header_expression) {
         isRequest_ = isRequest;
-
         parseOperation(set_header_expression);
     }
 
-    int SetHeaderProcessor::parseOperation(std::string& operation) {
+    int SetHeaderProcessor::parseOperation(absl::string_view operation_expression) {
         int err = 0;
-        // parse key
 
-        // parse values
+        // parse key and call setKey
+        std::string key = "mock_key";
+        setKey(key);
+
+        // parse values and call setVals
+        std::vector<std::string> vals({"mock_val1", "mock_val2"});
+        setVals(vals);
 
         // parse condition expression and call evaluate conditions on the parsed expression
-        std::string expression = "";
-        err = evaluateConditions(expression);
+        std::string condition_expression = "";
+        evaluateCondition(condition_expression);
+
         return err;
     }
 
-    int SetHeaderProcessor::evaluateConditions(std::string& conditions_expression) {
-        // split conditions by and
-        // search for negations
-        // for each condition, create a new ConditionProcessor instance and evaluate the condition
-        // evaluate the expression
-        bool result = true;
-
-        // set the condition based on the result
-        setCondition(result);
-
-        return 0;
+    int SetHeaderProcessor::evaluateCondition(absl::string_view condition_expression) {
+        int err = 0;
+        ConditionProcessor condition;
+        setCondition(condition.evaluateCondition(condition_expression));
+        return err;
     }
 
     int SetHeaderProcessor::evaluateOperation(RequestHeaderMap& headers) {
-        bool condition = getCondition();
-        const std::string& key = getKey();
-        const std::vector<std::string> header_vals = getVals();
+        int err = 0;
+        bool condition_result = getCondition(); // whether the condition is true or false
+        const std::string key = getKey();
+        const std::vector<std::string>& header_vals = getVals();
 
-        if (!condition) {
+        if (!condition_result) {
             // do nothing because condition is false
-            return 0;
+            return err;
         }
         
         // set header
@@ -67,8 +62,15 @@ namespace Http {
             headers.setCopy(LowerCaseString(key), header_val);
         }
 
-        return 0;
+        return err;
     }
+
+    // TODO: leaving implementation for later
+    int SetRequestPath::parseOperation(absl::string_view operation_expression) {return 0;}
+
+    int SetRequestPath::evaluateOperation(RequestHeaderMap& headers) {return 0;}
+
+    int SetRequestPath::evaluateCondition(absl::string_view condition_expression) {return 0;}
 
 } // namespace Http
 } // namespace Envoy

--- a/http-filter-example/header_processor.cc
+++ b/http-filter-example/header_processor.cc
@@ -1,0 +1,74 @@
+#include "header_processor.h"
+
+namespace Envoy {
+namespace Http {
+    ConditionProcessor::ConditionProcessor(std::string& condition_expression) {
+        parseCondition(condition_expression);
+    }
+
+    bool ConditionProcessor::evaluateCondition() {
+        // do map lookup
+        // map[name] -> ConditionProcessor
+
+        isTrue_ = 1;
+        return isTrue_;
+    }
+
+    int ConditionProcessor::parseCondition(std::string& condition_expression) {
+        // return immediately if condition has been evaluated
+        // else evaluate and add to map
+        return 0;
+    }
+
+
+    SetHeaderProcessor::SetHeaderProcessor(bool isRequest, std::string& set_header_expression) {
+        isRequest_ = isRequest;
+
+        parseOperation(set_header_expression);
+    }
+
+    int SetHeaderProcessor::parseOperation(std::string& operation) {
+        int err = 0;
+        // parse key
+
+        // parse values
+
+        // parse condition expression and call evaluate conditions on the parsed expression
+        std::string expression = "";
+        err = evaluateConditions(expression);
+        return err;
+    }
+
+    int SetHeaderProcessor::evaluateConditions(std::string& conditions_expression) {
+        // split conditions by and
+        // search for negations
+        // for each condition, create a new ConditionProcessor instance and evaluate the condition
+        // evaluate the expression
+        bool result = true;
+
+        // set the condition based on the result
+        setCondition(result);
+
+        return 0;
+    }
+
+    int SetHeaderProcessor::evaluateOperation(RequestHeaderMap& headers) {
+        bool condition = getCondition();
+        const std::string& key = getKey();
+        const std::vector<std::string> header_vals = getVals();
+
+        if (!condition) {
+            // do nothing because condition is false
+            return 0;
+        }
+        
+        // set header
+        for (auto const& header_val : header_vals) {
+            headers.setCopy(LowerCaseString(key), header_val);
+        }
+
+        return 0;
+    }
+
+} // namespace Http
+} // namespace Envoy

--- a/http-filter-example/header_processor.cc
+++ b/http-filter-example/header_processor.cc
@@ -2,30 +2,21 @@
 
 namespace Envoy {
 namespace Http {
-    
-    bool AclProcessor::evaluateAcl(absl::string_view acl_expression) {
-        int temp = 1;
-        if (acl_expression.length() > 0 || temp)
-            return true;
-        return true;
-    }
 
-    bool ConditionProcessor::evaluateCondition(absl::string_view condition_expression) {
-        // split condition_expression into each acl, send to acl processor
-        // take conjunction and possibly negation of each acl and return the result
-        return true;
-    }
-
-    SetHeaderProcessor::SetHeaderProcessor(bool isRequest, absl::string_view set_header_expression) {
+    SetHeaderProcessor::SetHeaderProcessor(bool isRequest) {
         isRequest_ = isRequest;
-        parseOperation(set_header_expression);
     }
 
-    int SetHeaderProcessor::parseOperation(absl::string_view operation_expression) {
+    int SetHeaderProcessor::parseOperation(std::vector<absl::string_view>& operation_expression) {
         int err = 0;
 
+        if (operation_expression.size() < 4) {
+            return 1;
+        }
+
         // parse key and call setKey
-        std::string key = "mock_key";
+        std::string key = std::string(operation_expression.at(2));
+        // std::string key = "mock_key";
         setKey(key);
 
         // parse values and call setVals
@@ -33,21 +24,19 @@ namespace Http {
         setVals(vals);
 
         // parse condition expression and call evaluate conditions on the parsed expression
-        std::string condition_expression = "";
-        evaluateCondition(condition_expression);
+        evaluateCondition();
 
         return err;
     }
 
-    int SetHeaderProcessor::evaluateCondition(absl::string_view condition_expression) {
+    int SetHeaderProcessor::evaluateCondition() {
         int err = 0;
-        ConditionProcessor condition;
-        setCondition(condition.evaluateCondition(condition_expression));
+        setCondition(true);
         return err;
     }
 
-    int SetHeaderProcessor::evaluateOperation(RequestHeaderMap& headers) {
-        int err = 0;
+    int SetHeaderProcessor::executeOperation(RequestHeaderMap& headers) const {
+        int err = 0; // TODO will set-header every return an error?
         bool condition_result = getCondition(); // whether the condition is true or false
         const std::string key = getKey();
         const std::vector<std::string>& header_vals = getVals();
@@ -59,18 +48,11 @@ namespace Http {
         
         // set header
         for (auto const& header_val : header_vals) {
-            headers.setCopy(LowerCaseString(key), header_val);
+            headers.addCopy(LowerCaseString(key), header_val);
         }
 
         return err;
     }
-
-    // TODO: leaving implementation for later
-    int SetRequestPath::parseOperation(absl::string_view operation_expression) {return 0;}
-
-    int SetRequestPath::evaluateOperation(RequestHeaderMap& headers) {return 0;}
-
-    int SetRequestPath::evaluateCondition(absl::string_view condition_expression) {return 0;}
 
 } // namespace Http
 } // namespace Envoy

--- a/http-filter-example/header_processor.cc
+++ b/http-filter-example/header_processor.cc
@@ -1,7 +1,9 @@
 #include "header_processor.h"
 
 namespace Envoy {
-namespace Http {
+namespace Extensions {
+namespace HttpFilters {
+namespace SampleFilter {
 
     SetHeaderProcessor::SetHeaderProcessor() {}
 
@@ -13,7 +15,7 @@ namespace Http {
         }
 
         // parse key and call setKey
-        std::string key = std::string(operation_expression.at(2));
+        absl::string_view key = operation_expression.at(2);
         setKey(key);
 
         // parse values and call setVals
@@ -35,24 +37,25 @@ namespace Http {
         return err;
     }
 
-    int SetHeaderProcessor::executeOperation(RequestHeaderMap& headers) const {
+    int SetHeaderProcessor::executeOperation(Http::RequestHeaderMap& headers) const {
         int err = 0; // TODO will executing set-header ever return an error?
         bool condition_result = getCondition(); // whether the condition is true or false
         const std::string key = getKey();
         const std::vector<std::string>& header_vals = getVals();
 
         if (!condition_result) {
-            // do nothing because condition is false
-            return err;
+            return err; // do nothing because condition is false
         }
         
         // set header
         for (auto const& header_val : header_vals) {
-            headers.addCopy(LowerCaseString(key), header_val);
+            headers.addCopy(Http::LowerCaseString(key), header_val);
         }
 
         return err;
     }
 
-} // namespace Http
+} // namespace SampleFilter
+} // namespace HttpFilters
+} // namespace Extensions
 } // namespace Envoy

--- a/http-filter-example/header_processor.cc
+++ b/http-filter-example/header_processor.cc
@@ -21,9 +21,14 @@ namespace SampleFilter {
         }
 
         // parse values and call setVals
-        std::vector<std::string> vals;
-        for (auto it = operation_expression.begin() + 3; it != operation_expression.end(); ++it) {
-            vals.push_back(std::string{*it});
+        try {
+            std::vector<std::string> vals;
+            for(auto it = operation_expression.begin() + 3; it != operation_expression.end(); ++it) { // could throw out of range
+                vals.push_back(std::string{*it}); // could through bad_alloc
+            }
+            setVals(vals);
+        } catch (const std::exception& e) {
+            return absl::InvalidArgumentError("error parsing header values");
         }
 
         // parse condition expression and call evaluate conditions on the parsed expression

--- a/http-filter-example/header_processor.cc
+++ b/http-filter-example/header_processor.cc
@@ -20,7 +20,7 @@ namespace SampleFilter {
 
         // parse values and call setVals
         std::vector<std::string> vals;
-        for(auto it = operation_expression.begin() + 3; it != operation_expression.end(); ++it) {
+        for (auto it = operation_expression.begin() + 3; it != operation_expression.end(); ++it) {
             vals.push_back(std::string{*it});
         }
         setVals(vals);

--- a/http-filter-example/header_processor.cc
+++ b/http-filter-example/header_processor.cc
@@ -3,9 +3,7 @@
 namespace Envoy {
 namespace Http {
 
-    SetHeaderProcessor::SetHeaderProcessor(bool isRequest) {
-        isRequest_ = isRequest;
-    }
+    SetHeaderProcessor::SetHeaderProcessor() {}
 
     int SetHeaderProcessor::parseOperation(std::vector<absl::string_view>& operation_expression) {
         int err = 0;
@@ -16,11 +14,13 @@ namespace Http {
 
         // parse key and call setKey
         std::string key = std::string(operation_expression.at(2));
-        // std::string key = "mock_key";
         setKey(key);
 
         // parse values and call setVals
-        std::vector<std::string> vals({"mock_val1", "mock_val2"});
+        std::vector<std::string> vals;
+        for(auto it = operation_expression.begin() + 3; it != operation_expression.end(); ++it) {
+            vals.push_back(std::string{*it});
+        }
         setVals(vals);
 
         // parse condition expression and call evaluate conditions on the parsed expression
@@ -36,7 +36,7 @@ namespace Http {
     }
 
     int SetHeaderProcessor::executeOperation(RequestHeaderMap& headers) const {
-        int err = 0; // TODO will set-header every return an error?
+        int err = 0; // TODO will executing set-header ever return an error?
         bool condition_result = getCondition(); // whether the condition is true or false
         const std::string key = getKey();
         const std::vector<std::string>& header_vals = getVals();

--- a/http-filter-example/header_processor.cc
+++ b/http-filter-example/header_processor.cc
@@ -8,23 +8,20 @@ namespace SampleFilter {
     SetHeaderProcessor::SetHeaderProcessor() {}
 
     absl::Status SetHeaderProcessor::parseOperation(std::vector<absl::string_view>& operation_expression) {
-        if (operation_expression.size() < 4) {
-            return absl::InvalidArgumentError("too few arguments");
-        }
-
         // parse key and call setKey
         try {
-            absl::string_view key = operation_expression.at(2); // could throw out of range
+            absl::string_view key = operation_expression.at(2);
             setKey(key);
-        } catch (const std::out_of_range& oor) {
+        } catch (const std::exception& e) {
+            // should never happen, range is checked in HTTP filter
             return absl::InvalidArgumentError("error parsing header key");
         }
 
         // parse values and call setVals
         try {
             std::vector<std::string> vals;
-            for(auto it = operation_expression.begin() + 3; it != operation_expression.end(); ++it) { // could throw out of range
-                vals.push_back(std::string{*it}); // could through bad_alloc
+            for(auto it = operation_expression.begin() + 3; it != operation_expression.end(); ++it) {
+                vals.push_back(std::string{*it}); // could throw bad_alloc
             }
             setVals(vals);
         } catch (const std::exception& e) {

--- a/http-filter-example/header_processor.h
+++ b/http-filter-example/header_processor.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace Envoy {
+namespace Http {
+
+enum Operation {
+  OP_SET_HEADER = 0,
+  OP_SET_PATH = 1,
+};
+
+enum DynamicValue {
+  DYN_URLP = 0,
+  DYN_HDR = 1
+};
+
+class Condition {
+public:
+  Condition(std::string& condition); // make this a string_view
+  ~Condition();
+
+  int parseCondition(std::string& condition);
+  int evaluateCondition();
+};
+
+class HeaderProcessor {
+public:
+  virtual int parseOperation(std::string& operation); // parses the arguments + condition, sends condition to its own class to be parsed
+  virtual int evaluateOperation();
+};
+
+class SetHeaderProcessor : public HeaderProcessor {
+public:
+  SetHeaderProcessor(bool isRequest, std::string& set_header_expression);
+  ~SetHeaderProcessor();
+
+private:
+  std::string fetchDynamicValue(DynamicValue val);
+
+  bool isRequest_;
+  std::string header_key_;
+  std::vector<std::string> header_vals_;
+  Envoy::Http::Condition condition_;
+};
+
+class SetRequestPath : public HeaderProcessor {
+public:
+  SetRequestPath();
+  ~SetRequestPath();
+
+private:
+  std::string path_;
+  Envoy::Http::Condition condition_;
+};
+
+} // namespace Http
+} // namespace Envoy

--- a/http-filter-example/header_processor.h
+++ b/http-filter-example/header_processor.h
@@ -13,9 +13,9 @@ namespace SampleFilter {
 class HeaderProcessor {
 public:
   virtual ~HeaderProcessor() {};
-  virtual int parseOperation(std::vector<absl::string_view>& operation_expression) = 0;
-  virtual int executeOperation(Http::RequestHeaderMap& headers) const = 0;
-  virtual int evaluateCondition() = 0;
+  virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression) = 0;
+  virtual void executeOperation(Http::RequestHeaderMap& headers) const = 0;
+  virtual absl::Status evaluateCondition() = 0;
   bool getCondition() const { return condition_; }
   void setCondition(bool result) { condition_ = result; }
 
@@ -27,10 +27,9 @@ class SetHeaderProcessor : public HeaderProcessor {
 public:
   SetHeaderProcessor();
   virtual ~SetHeaderProcessor() {}
-  // SetHeaderProcessor& operator=(const SetHeaderProcessor&) = delete;
-  virtual int parseOperation(std::vector<absl::string_view>& operation_expression);
-  virtual int executeOperation(Http::RequestHeaderMap& headers) const;
-  virtual int evaluateCondition(); // TODO: will need to pass http-related metadata in order to evaluate dynamic values
+  virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression);
+  virtual void executeOperation(Http::RequestHeaderMap& headers) const;
+  virtual absl::Status evaluateCondition(); // TODO: will need to pass http-related metadata in order to evaluate dynamic values
 
   // Note: the values returned by these functions must not outlive the SetHeaderProcessor object
   const std::string& getKey() const { return header_key_; }
@@ -39,9 +38,14 @@ public:
   void setKey(absl::string_view key) { header_key_ = std::string(key); }
   void setVals(std::vector<std::string> vals) { header_vals_ = vals; }
 
+  // TODO: should each operation store an error?
+  void setError() { error_ = true; }
+  bool getError() { return error_; }
+
 private:
   std::string header_key_; // header key to set
   std::vector<std::string> header_vals_; // header values to set
+  bool error_ = false;
 };
 
 } // namespace SampleFilter

--- a/http-filter-example/header_processor.h
+++ b/http-filter-example/header_processor.h
@@ -11,7 +11,7 @@ namespace Http {
 class HeaderProcessor {
 public:
   virtual ~HeaderProcessor() {};
-  virtual int parseOperation(std::vector<absl::string_view>& operation_expression) = 0; // parses the arguments + condition, sends each acl to AclProcessor to be parsed
+  virtual int parseOperation(std::vector<absl::string_view>& operation_expression) = 0;
   virtual int executeOperation(RequestHeaderMap& headers) const = 0;
   virtual int evaluateCondition() = 0;
   bool getCondition() const { return condition_; }
@@ -23,7 +23,7 @@ protected:
 
 class SetHeaderProcessor : public HeaderProcessor {
 public:
-  SetHeaderProcessor(bool isRequest);
+  SetHeaderProcessor();
   virtual ~SetHeaderProcessor() {}
   virtual int parseOperation(std::vector<absl::string_view>& operation_expression);
   virtual int executeOperation(RequestHeaderMap& headers) const;
@@ -33,10 +33,8 @@ public:
   const std::vector<std::string>& getVals() const { return header_vals_; }
   void setKey(std::string key) { header_key_ = key; }
   void setVals(std::vector<std::string> vals) { header_vals_ = vals; }
-  bool isHttpRequest() const { return isRequest_; } // possibly superfluous
 
 private:
-  bool isRequest_; // possibly superfluous: http filter will use this to determine whether to evaluate the operation in encodeHeaders or decodeHeaders
   std::string header_key_; // header key to set
   std::vector<std::string> header_vals_; // header values to set
 };

--- a/http-filter-example/header_processor.h
+++ b/http-filter-example/header_processor.h
@@ -8,38 +8,12 @@
 namespace Envoy {
 namespace Http {
 
-enum DynamicValue {
-  DYN_URLP = 0,
-  DYN_HDR = 1
-};
-
-class AclProcessor {
-public:
-  AclProcessor() {}
-  ~AclProcessor() {}
-  bool evaluateAcl(absl::string_view acl_expression);
-
-private:
-  bool isTrue_; // not needed?
-};
-
-class ConditionProcessor {
-public:
-  ConditionProcessor() {}
-  ~ConditionProcessor() {}
-  bool evaluateCondition(absl::string_view condition_expression);
-
-private:
-  std::vector<Envoy::Http::AclProcessor> acl_processors_; // is there a need to store each acl?
-  bool isTrue_; // not needed? can directly return the result without storing it
-};
-
 class HeaderProcessor {
 public:
-  virtual ~HeaderProcessor() = default;
-  virtual int parseOperation(absl::string_view operation_expression) = 0; // parses the arguments + condition, sends each acl to AclProcessor to be parsed
-  virtual int evaluateOperation(RequestHeaderMap& headers) = 0;
-  virtual int evaluateCondition(absl::string_view condition_expression) = 0;
+  virtual ~HeaderProcessor() {};
+  virtual int parseOperation(std::vector<absl::string_view>& operation_expression) = 0; // parses the arguments + condition, sends each acl to AclProcessor to be parsed
+  virtual int executeOperation(RequestHeaderMap& headers) const = 0;
+  virtual int evaluateCondition() = 0;
   bool getCondition() const { return condition_; }
   void setCondition(bool result) { condition_ = result; }
 
@@ -49,11 +23,11 @@ protected:
 
 class SetHeaderProcessor : public HeaderProcessor {
 public:
-  SetHeaderProcessor(bool isRequest, absl::string_view set_header_expression);
+  SetHeaderProcessor(bool isRequest);
   virtual ~SetHeaderProcessor() {}
-  virtual int parseOperation(absl::string_view operation_expression);
-  virtual int evaluateOperation(RequestHeaderMap& headers);
-  virtual int evaluateCondition(absl::string_view condition_expression); // TODO: will need to pass http-related metadata in order to evaluate dynamic values
+  virtual int parseOperation(std::vector<absl::string_view>& operation_expression);
+  virtual int executeOperation(RequestHeaderMap& headers) const;
+  virtual int evaluateCondition(); // TODO: will need to pass http-related metadata in order to evaluate dynamic values
 
   const std::string& getKey() const { return header_key_; }
   const std::vector<std::string>& getVals() const { return header_vals_; }
@@ -62,23 +36,9 @@ public:
   bool isHttpRequest() const { return isRequest_; } // possibly superfluous
 
 private:
-  std::string fetchDynamicValue(DynamicValue val); // TODO: fetch query params, header values, etc -- leaving implementation for later, possibly need to make a separate class
-
   bool isRequest_; // possibly superfluous: http filter will use this to determine whether to evaluate the operation in encodeHeaders or decodeHeaders
   std::string header_key_; // header key to set
   std::vector<std::string> header_vals_; // header values to set
-};
-
-class SetRequestPath : public HeaderProcessor {
-public:
-  SetRequestPath();
-  virtual ~SetRequestPath() {}
-  virtual int parseOperation(absl::string_view operation_expression);
-  virtual int evaluateOperation(RequestHeaderMap& headers);
-  virtual int evaluateCondition(absl::string_view condition_expression);
-
-private:
-  std::string path_; // path to set
 };
 
 } // namespace Http

--- a/http-filter-example/header_processor.h
+++ b/http-filter-example/header_processor.h
@@ -6,13 +6,15 @@
 #include <vector>
 
 namespace Envoy {
-namespace Http {
+namespace Extensions {
+namespace HttpFilters {
+namespace SampleFilter {
 
 class HeaderProcessor {
 public:
   virtual ~HeaderProcessor() {};
   virtual int parseOperation(std::vector<absl::string_view>& operation_expression) = 0;
-  virtual int executeOperation(RequestHeaderMap& headers) const = 0;
+  virtual int executeOperation(Http::RequestHeaderMap& headers) const = 0;
   virtual int evaluateCondition() = 0;
   bool getCondition() const { return condition_; }
   void setCondition(bool result) { condition_ = result; }
@@ -25,13 +27,16 @@ class SetHeaderProcessor : public HeaderProcessor {
 public:
   SetHeaderProcessor();
   virtual ~SetHeaderProcessor() {}
+  // SetHeaderProcessor& operator=(const SetHeaderProcessor&) = delete;
   virtual int parseOperation(std::vector<absl::string_view>& operation_expression);
-  virtual int executeOperation(RequestHeaderMap& headers) const;
+  virtual int executeOperation(Http::RequestHeaderMap& headers) const;
   virtual int evaluateCondition(); // TODO: will need to pass http-related metadata in order to evaluate dynamic values
 
+  // Note: the values returned by these functions must not outlive the SetHeaderProcessor object
   const std::string& getKey() const { return header_key_; }
   const std::vector<std::string>& getVals() const { return header_vals_; }
-  void setKey(std::string key) { header_key_ = key; }
+
+  void setKey(absl::string_view key) { header_key_ = std::string(key); }
   void setVals(std::vector<std::string> vals) { header_vals_ = vals; }
 
 private:
@@ -39,5 +44,7 @@ private:
   std::vector<std::string> header_vals_; // header values to set
 };
 
-} // namespace Http
+} // namespace SampleFilter
+} // namespace HttpFilters
+} // namespace Extensions
 } // namespace Envoy

--- a/http-filter-example/http_filter.cc
+++ b/http-filter-example/http_filter.cc
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "http_filter.h"
+#include "utility.h"
 
 #include "source/common/common/utility.h"
 #include "source/common/common/logger.h"
@@ -34,24 +35,37 @@ HttpSampleDecoderFilter::HttpSampleDecoderFilter(HttpSampleDecoderFilterConfigSh
   // process each operation
   for (auto const& operation : operations) {
     auto tokens = StringUtil::splitToken(operation, " ");
-    if (tokens.size() < 3) {
+    if (tokens.size() < Utility::MIN_NUM_ARGUMENTS) {
       fail("too few arguments provided");
       setError();
       return; // TODO: should we quit here or continue to process operations that are grammatical?
     }
 
     // determine if it's request/response
-    if (tokens[0] != "http-request" && tokens[0] != "http-response") {
+    if (tokens.at(0) != Utility::HTTP_REQUEST && tokens.at(0) != Utility::HTTP_RESPONSE) {
       fail("first argument must be <http-response/http-request>");
       setError();
       return; // TODO: should we quit here or continue to process operations that are grammatical?
     }
-    const bool isRequest = (tokens[0] == "http-request");
+    const bool isRequest = (tokens.at(0) == "http-request");
 
-    // TODO: determine the operation type (right now I'm assuming that it's always a set-header operation)
+    Utility::OperationType operation_type = Utility::StringToOperationType(absl::string_view(tokens.at(1)));
+    HeaderProcessorUniquePtr processor;
 
-    // make new header processor
-    HeaderProcessorUniquePtr processor = std::make_unique<SetHeaderProcessor>();
+    switch(operation_type) {
+      case Utility::OperationType::kSetHeader:
+        // make new header processor
+        processor = std::make_unique<SetHeaderProcessor>();
+        break;
+      case Utility::OperationType::kSetPath:
+        // TODO: implement set-path operation
+        ENVOY_LOG_MISC(info, "set path operation detected!");
+        return;
+      default:
+        fail("invalid operation type");
+        setError(1); // TODO: change this to setError() once error checks PR is merged
+        return;
+    }
 
     // parse operation
     absl::Status status = processor->parseOperation(tokens);

--- a/http-filter-example/http_filter.cc
+++ b/http-filter-example/http_filter.cc
@@ -63,7 +63,7 @@ HttpSampleDecoderFilter::HttpSampleDecoderFilter(HttpSampleDecoderFilterConfigSh
         return;
       default:
         fail("invalid operation type");
-        setError(1); // TODO: change this to setError() once error checks PR is merged
+        setError(); // TODO: change this to setError() once error checks PR is merged
         return;
     }
 

--- a/http-filter-example/http_filter.cc
+++ b/http-filter-example/http_filter.cc
@@ -54,7 +54,6 @@ HttpSampleDecoderFilter::HttpSampleDecoderFilter(HttpSampleDecoderFilterConfigSh
 
     switch(operation_type) {
       case Utility::OperationType::kSetHeader:
-        // make new header processor
         processor = std::make_unique<SetHeaderProcessor>();
         break;
       case Utility::OperationType::kSetPath:
@@ -63,7 +62,7 @@ HttpSampleDecoderFilter::HttpSampleDecoderFilter(HttpSampleDecoderFilterConfigSh
         return;
       default:
         fail("invalid operation type");
-        setError(); // TODO: change this to setError() once error checks PR is merged
+        setError();
         return;
     }
 

--- a/http-filter-example/http_filter.cc
+++ b/http-filter-example/http_filter.cc
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "http_filter.h"
+#include "utility.h"
 
 #include "source/common/common/utility.h"
 #include "source/common/common/logger.h"
@@ -34,24 +35,37 @@ HttpSampleDecoderFilter::HttpSampleDecoderFilter(HttpSampleDecoderFilterConfigSh
   // process each operation
   for (auto const& operation : operations) {
     auto tokens = StringUtil::splitToken(operation, " ");
-    if (tokens.size() < 3) {
+    if (tokens.size() < Utility::MIN_NUM_ARGUMENTS) {
       fail("too few arguments provided");
       setError(1); // TODO: set error based on globally defined macros
       return;
     }
 
     // determine if it's request/response
-    if (tokens[0] != "http-request" && tokens[0] != "http-response") {
+    if (tokens.at(0) != Utility::HTTP_REQUEST && tokens.at(0) != Utility::HTTP_RESPONSE) {
       fail("first argument must be <http-response/http-request>");
       setError(1); // TODO: set error based on globally defined macros
       return;
     }
-    const bool isRequest = (tokens[0] == "http-request");
+    const bool isRequest = (tokens.at(0) == "http-request");
 
-    // TODO: determine the operation type (right now I'm assuming that it's always a set-header operation)
+    Utility::OperationType operation_type = Utility::StringToOperationType(absl::string_view(tokens.at(1)));
+    HeaderProcessorUniquePtr processor;
 
-    // make new header processor
-    HeaderProcessorUniquePtr processor = std::make_unique<SetHeaderProcessor>();
+    switch(operation_type) {
+      case Utility::OperationType::kSetHeader:
+        // make new header processor
+        processor = std::make_unique<SetHeaderProcessor>();
+        break;
+      case Utility::OperationType::kSetPath:
+        // TODO: implement set-path operation
+        ENVOY_LOG_MISC(info, "set path operation detected!");
+        return;
+      default:
+        fail("invalid operation type");
+        setError(1); // TODO: change this to setError() once error checks PR is merged
+        return;
+    }
 
     // parse operation
     if (processor->parseOperation(tokens)) {

--- a/http-filter-example/http_filter.cc
+++ b/http-filter-example/http_filter.cc
@@ -47,16 +47,16 @@ HttpSampleDecoderFilter::HttpSampleDecoderFilter(HttpSampleDecoderFilterConfigSh
       setError();
       return; // TODO: should we quit here or continue to process operations that are grammatical?
     }
-    const bool isRequest = (tokens.at(0) == "http-request");
+    const bool isRequest = (tokens.at(0) == Utility::HTTP_REQUEST);
 
-    Utility::OperationType operation_type = Utility::StringToOperationType(absl::string_view(tokens.at(1)));
+    const Utility::OperationType operation_type = Utility::StringToOperationType(absl::string_view(tokens.at(1)));
     HeaderProcessorUniquePtr processor;
 
     switch(operation_type) {
-      case Utility::OperationType::kSetHeader:
+      case Utility::OperationType::SetHeader:
         processor = std::make_unique<SetHeaderProcessor>();
         break;
-      case Utility::OperationType::kSetPath:
+      case Utility::OperationType::SetPath:
         // TODO: implement set-path operation
         ENVOY_LOG_MISC(info, "set path operation detected!");
         return;

--- a/http-filter-example/http_filter.cc
+++ b/http-filter-example/http_filter.cc
@@ -66,25 +66,6 @@ HttpSampleDecoderFilter::HttpSampleDecoderFilter(HttpSampleDecoderFilterConfigSh
         setError(); // TODO: change this to setError() once error checks PR is merged
         return;
     }
-    const bool isRequest = (tokens.at(0) == "http-request");
-
-    Utility::OperationType operation_type = Utility::StringToOperationType(absl::string_view(tokens.at(1)));
-    HeaderProcessorUniquePtr processor;
-
-    switch(operation_type) {
-      case Utility::OperationType::kSetHeader:
-        // make new header processor
-        processor = std::make_unique<SetHeaderProcessor>();
-        break;
-      case Utility::OperationType::kSetPath:
-        // TODO: implement set-path operation
-        ENVOY_LOG_MISC(info, "set path operation detected!");
-        return;
-      default:
-        fail("invalid operation type");
-        setError(); // TODO: change this to setError() once error checks PR is merged
-        return;
-    }
 
     // parse operation
     absl::Status status = processor->parseOperation(tokens);

--- a/http-filter-example/http_filter.cc
+++ b/http-filter-example/http_filter.cc
@@ -38,14 +38,14 @@ HttpSampleDecoderFilter::HttpSampleDecoderFilter(HttpSampleDecoderFilterConfigSh
     if (tokens.size() < Utility::MIN_NUM_ARGUMENTS) {
       fail("too few arguments provided");
       setError();
-      return; // TODO: should we quit here or continue to process operations that are grammatical?
+      return;
     }
 
     // determine if it's request/response
     if (tokens.at(0) != Utility::HTTP_REQUEST && tokens.at(0) != Utility::HTTP_RESPONSE) {
       fail("first argument must be <http-response/http-request>");
       setError();
-      return; // TODO: should we quit here or continue to process operations that are grammatical?
+      return;
     }
     const bool isRequest = (tokens.at(0) == Utility::HTTP_REQUEST);
 
@@ -67,11 +67,11 @@ HttpSampleDecoderFilter::HttpSampleDecoderFilter(HttpSampleDecoderFilterConfigSh
     }
 
     // parse operation
-    absl::Status status = processor->parseOperation(tokens);
+    const absl::Status status = processor->parseOperation(tokens);
     if (!status.ok()) {
       fail(status.message());
       setError();
-      return; // TODO: should we quit here or continue to process operations that are grammatical?
+      return;
     }
 
     // keep track of operations to be executed
@@ -91,7 +91,7 @@ const std::string HttpSampleDecoderFilter::headerValue() const {
 
 Http::FilterHeadersStatus HttpSampleDecoderFilter::decodeHeaders(Http::RequestHeaderMap& headers, bool) {
   if (getError()) {
-    ENVOY_LOG_MISC(info, "invalid config, skipping filter"); // TODO: do we quit here or execute operations that are grammatical?
+    ENVOY_LOG_MISC(info, "invalid config, skipping filter");
     return Http::FilterHeadersStatus::Continue;
   }
 

--- a/http-filter-example/http_filter.h
+++ b/http-filter-example/http_filter.h
@@ -3,6 +3,8 @@
 #include <string>
 #include <unordered_set>
 
+#include "header_processor.h"
+
 #include "source/extensions/filters/http/common/pass_through_filter.h"
 #include "envoy/common/exception.h"
 #include "http-filter-example/http_filter.pb.h"
@@ -44,11 +46,15 @@ private:
   StreamDecoderFilterCallbacks* decoder_callbacks_;
   int error_ = 0;
 
+  // header processors
+  // TODO: add one for response header processing once filter is converted to Encoder/Decoder
+  std::vector<HeaderProcessor*> request_header_processors_;
+
   // set of accepted operations
   std::unordered_set<std::string> operations_;
 
-  //key is header operation, value is a vector of arguments for the operation
-  std::unordered_map<std::string, std::vector<std::string>> header_ops_;
+  // key is header operation, value is a vector of arguments for the operation
+  // std::unordered_map<std::string, std::vector<std::string>> header_ops_;
 
   const LowerCaseString headerKey() const;
   const std::string headerValue() const;
@@ -57,10 +63,10 @@ private:
   int getError() const;
 };
 
-class FilterException : public EnvoyException {
-public:
-  using EnvoyException::EnvoyException;
-};
+// class FilterException : public EnvoyException {
+// public:
+//   using EnvoyException::EnvoyException;
+// };
 
 } // namespace Http
 } // namespace Envoy

--- a/http-filter-example/http_filter.h
+++ b/http-filter-example/http_filter.h
@@ -10,7 +10,9 @@
 #include "http-filter-example/http_filter.pb.h"
 
 namespace Envoy {
-namespace Http {
+namespace Extensions {
+namespace HttpFilters {
+namespace SampleFilter {
 
 class HttpSampleDecoderFilterConfig {
 public:
@@ -18,43 +20,41 @@ public:
 
   const std::string& key() const { return key_; }
   const std::string& val() const { return val_; }
-  int extra() const { return extra_; }
 
 private:
   const std::string key_;
   const std::string val_;
-  const int extra_ = 0;
 };
 
 using HttpSampleDecoderFilterConfigSharedPtr = std::shared_ptr<HttpSampleDecoderFilterConfig>;
+using HeaderProcessorUniquePtr = std::unique_ptr<HeaderProcessor>;
 
-class HttpSampleDecoderFilter : public PassThroughDecoderFilter {
+class HttpSampleDecoderFilter : public Http::PassThroughDecoderFilter {
 public:
   HttpSampleDecoderFilter(HttpSampleDecoderFilterConfigSharedPtr);
-  ~HttpSampleDecoderFilter();
+  ~HttpSampleDecoderFilter() {}
 
-  void onDestroy() override;
+  void onDestroy() override {}
 
   // Http::StreamDecoderFilter
-  FilterHeadersStatus decodeHeaders(RequestHeaderMap&, bool) override;
-  FilterDataStatus decodeData(Buffer::Instance&, bool) override;
-  void setDecoderFilterCallbacks(StreamDecoderFilterCallbacks&) override;
+  Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap&, bool) override;
+  Http::FilterDataStatus decodeData(Buffer::Instance&, bool) override;
+  void setDecoderFilterCallbacks(Http::StreamDecoderFilterCallbacks&) override;
 
 private:
   const HttpSampleDecoderFilterConfigSharedPtr config_;
-  StreamDecoderFilterCallbacks* decoder_callbacks_;
+  Http::StreamDecoderFilterCallbacks* decoder_callbacks_;
   int error_ = 0;
 
   // header processors
   // TODO: add one for response header processing once filter is converted to Encoder/Decoder
-  std::vector<HeaderProcessor*> request_header_processors_;
+  std::vector<HeaderProcessorUniquePtr> request_header_processors_;
 
   // set of accepted operations
   std::unordered_set<std::string> operations_;
 
-  const LowerCaseString headerKey() const;
+  const Http::LowerCaseString headerKey() const;
   const std::string headerValue() const;
-  int headerExtra() const;
   void setError(const int val);
   int getError() const;
 };
@@ -65,5 +65,7 @@ private:
 //   using EnvoyException::EnvoyException;
 // };
 
-} // namespace Http
+} // namespace SampleFilter
+} // namespace HttpFilters
+} // namespace Extensions
 } // namespace Envoy

--- a/http-filter-example/http_filter.h
+++ b/http-filter-example/http_filter.h
@@ -33,7 +33,6 @@ public:
   HttpSampleDecoderFilter(HttpSampleDecoderFilterConfigSharedPtr);
   ~HttpSampleDecoderFilter();
 
-  // Http::StreamFilterBase
   void onDestroy() override;
 
   // Http::StreamDecoderFilter
@@ -53,9 +52,6 @@ private:
   // set of accepted operations
   std::unordered_set<std::string> operations_;
 
-  // key is header operation, value is a vector of arguments for the operation
-  // std::unordered_map<std::string, std::vector<std::string>> header_ops_;
-
   const LowerCaseString headerKey() const;
   const std::string headerValue() const;
   int headerExtra() const;
@@ -63,6 +59,7 @@ private:
   int getError() const;
 };
 
+// TODO: might need to throw an exception in the future
 // class FilterException : public EnvoyException {
 // public:
 //   using EnvoyException::EnvoyException;

--- a/http-filter-example/http_filter.h
+++ b/http-filter-example/http_filter.h
@@ -44,7 +44,7 @@ public:
 private:
   const HttpSampleDecoderFilterConfigSharedPtr config_;
   Http::StreamDecoderFilterCallbacks* decoder_callbacks_;
-  int error_ = 0;
+  bool error_ = false;
 
   // header processors
   // TODO: add one for response header processing once filter is converted to Encoder/Decoder
@@ -55,8 +55,8 @@ private:
 
   const Http::LowerCaseString headerKey() const;
   const std::string headerValue() const;
-  void setError(const int val);
-  int getError() const;
+  void setError() { error_ = true; }
+  bool getError() const { return error_; };
 };
 
 // TODO: might need to throw an exception in the future

--- a/http-filter-example/http_filter.h
+++ b/http-filter-example/http_filter.h
@@ -32,7 +32,7 @@ using HeaderProcessorUniquePtr = std::unique_ptr<HeaderProcessor>;
 class HttpSampleDecoderFilter : public Http::PassThroughDecoderFilter {
 public:
   HttpSampleDecoderFilter(HttpSampleDecoderFilterConfigSharedPtr);
-  ~HttpSampleDecoderFilter() {}
+  virtual ~HttpSampleDecoderFilter() {}
 
   void onDestroy() override {}
 

--- a/http-filter-example/http_filter.proto
+++ b/http-filter-example/http_filter.proto
@@ -7,5 +7,4 @@ import "validate/validate.proto";
 message Decoder {
     string key = 1 [(validate.rules).string.min_len = 1];
     string val = 2 [(validate.rules).string.min_len = 1];
-    string extra = 3 [(validate.rules).string.min_len = 1];
 }

--- a/http-filter-example/http_filter_config.cc
+++ b/http-filter-example/http_filter_config.cc
@@ -33,12 +33,12 @@ public:
 
 private:
   Http::FilterFactoryCb createFilter(const sample::Decoder& proto_config, FactoryContext&) {
-    Http::HttpSampleDecoderFilterConfigSharedPtr config =
-        std::make_shared<Http::HttpSampleDecoderFilterConfig>(
-            Http::HttpSampleDecoderFilterConfig(proto_config));
+    Extensions::HttpFilters::SampleFilter::HttpSampleDecoderFilterConfigSharedPtr config =
+        std::make_shared<Extensions::HttpFilters::SampleFilter::HttpSampleDecoderFilterConfig>(
+            Extensions::HttpFilters::SampleFilter::HttpSampleDecoderFilterConfig(proto_config));
 
     return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-      auto filter = new Http::HttpSampleDecoderFilter(config);
+      auto filter = new Extensions::HttpFilters::SampleFilter::HttpSampleDecoderFilter(config);
       callbacks.addStreamDecoderFilter(Http::StreamDecoderFilterSharedPtr{filter});
     };
   }

--- a/http-filter-example/utility.cc
+++ b/http-filter-example/utility.cc
@@ -8,11 +8,11 @@ namespace Utility {
 
  OperationType StringToOperationType(absl::string_view operation) {
     if (operation == "set-header") {
-        return OperationType::kSetHeader;
+        return OperationType::SetHeader;
     } else if (operation == "set-path") {
-        return OperationType::kSetPath;
+        return OperationType::SetPath;
     } else {
-        return OperationType::kInvalidOperation;
+        return OperationType::InvalidOperation;
     }
 }
 

--- a/http-filter-example/utility.cc
+++ b/http-filter-example/utility.cc
@@ -1,0 +1,23 @@
+#include "utility.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace SampleFilter {
+namespace Utility {
+
+ OperationType StringToOperationType(absl::string_view operation) {
+    if (operation == "set-header") {
+        return OperationType::kSetHeader;
+    } else if (operation == "set-path") {
+        return OperationType::kSetPath;
+    } else {
+        return OperationType::kInvalidOperation;
+    }
+}
+
+} // namespace Utility
+} // namespace SampleFilter
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/http-filter-example/utility.h
+++ b/http-filter-example/utility.h
@@ -14,10 +14,9 @@ constexpr absl::string_view HTTP_REQUEST = "http-request";
 constexpr absl::string_view HTTP_RESPONSE = "http-response";
 
 enum class OperationType : int {
-  kSetHeader,
-  kSetPath,
-  NUM_OPERATIONS,
-  kInvalidOperation,
+  SetHeader,
+  SetPath,
+  InvalidOperation,
 };
 
 OperationType StringToOperationType(absl::string_view operation);

--- a/http-filter-example/utility.h
+++ b/http-filter-example/utility.h
@@ -8,7 +8,7 @@ namespace HttpFilters {
 namespace SampleFilter {
 namespace Utility {
 
-constexpr uint8_t MIN_NUM_ARGUMENTS = 3;
+constexpr uint8_t MIN_NUM_ARGUMENTS = 4;
 
 constexpr absl::string_view HTTP_REQUEST = "http-request";
 constexpr absl::string_view HTTP_RESPONSE = "http-response";

--- a/http-filter-example/utility.h
+++ b/http-filter-example/utility.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "absl/strings/string_view.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace SampleFilter {
+namespace Utility {
+
+constexpr uint8_t MIN_NUM_ARGUMENTS = 3;
+
+constexpr absl::string_view HTTP_REQUEST = "http-request";
+constexpr absl::string_view HTTP_RESPONSE = "http-response";
+
+enum class OperationType : int {
+  kSetHeader,
+  kSetPath,
+  NUM_OPERATIONS,
+  kInvalidOperation,
+};
+
+OperationType StringToOperationType(absl::string_view operation);
+
+} // namespace Utility
+} // namespace SampleFilter
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy


### PR DESCRIPTION
### Description
(See also: [EDGEBE-375])

This PR makes use of a proposed C++ AST-style [framework](https://github.com/DataDog/envoy-filter-example/pull/2) to perform a sequence of set-header operations. For example, the following config will modify the `x-forwarded-proto` header to have the value `https`. 


```
- name: sample
            typed_config:
              "@type": type.googleapis.com/sample.Decoder
              key: header-processing
              val: "http-request set-header x-forwarded-proto https"
```

This implementation can take in a newline-delimited sequence of set header operations and also supports adding multiple values to a header.

See [this doc](https://datadoghq.atlassian.net/wiki/spaces/~712020ba1b13e5868d45e49dbc041828ac0041/blog/2023/06/30/3077636109/Building+Running+an+Envoy+Filter+Plugin) for more documentation on building and running the envoy filter plugin.

### Testing
```
// Write a config for the filter
// Eg. "http-request set-header x-forwarded-proto https\n http-request set-header mock_key mock_val1 mock_val2"

// Build and run envoy
bazel build //http-filter-example:envoy
./bazel-bin/http-filter-example/envoy -c ./http-filter-example/envoy-sample-config.yaml

// Set up Docker backend to echo http headers and send a curl request to envoy
// Docker image found here: https://hub.docker.com/r/ealen/echo-server
curl localhost:8081
```

We can see the specified headers have been added/modified:
```
ubuntu@ip-10-128-172-195:~$ curl localhost:8081
{"host":{"hostname":"localhost","ip":"::ffff:172.17.0.1","ips":[]},"http":{"method":"GET","baseUrl":"","originalUrl":"/","protocol":"http"},"request":{"params":{"0":"/"},"query":{},"cookies":{},"body":{},"headers":{"host":"localhost:8081","user-agent":"curl/7.68.0","accept":"*/*","x-forwarded-proto":"http,https","x-request-id":"8918d17d-a807-4619-ad06-d6ff39ad006b","mock_key":"mock_val1, mock_val2","x-envoy-expected-rq-timeout-ms":"15000"}},"environment":{"PATH":"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin","HOSTNAME":"e6cf43c557fd","NODE_VERSION":"16.16.0","YARN_VERSION":"1.22.19","HOME":"/root"}}
```

### Notes

- This is a very basic implementation -- I added TODOs next to the areas that need to be built out more
- This implementation adds the indicated header values to a header field, ie it will not replace what is already there -- will need to determine the cases in which to replace the header values

[EDGEBE-375]: https://datadoghq.atlassian.net/browse/EDGEBE-375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ