### PR TITLE
Define constants

### DIFF
--- a/http-filter-example/BUILD
+++ b/http-filter-example/BUILD
@@ -27,6 +27,7 @@ envoy_cc_library(
     deps = [
         ":pkg_cc_proto",
         ":http_header_processor_lib",
+        ":http_header_processor_utils_lib",
         "@envoy//source/extensions/filters/http/common:pass_through_filter_lib",
         "@envoy//source/common/common:utility_lib",
         "@envoy//source/common/common:minimal_logger_lib",
@@ -46,7 +47,19 @@ envoy_cc_library(
 envoy_cc_library(
     name = "http_header_processor_lib",
     srcs = ["header_processor.cc"],
-    hdrs = ["header_processor.h"],
+    hdrs = [ "header_processor.h"],
+    repository = "@envoy",
+    deps = [
+        ":pkg_cc_proto",
+        ":http_header_processor_utils_lib",
+        "@envoy//source/extensions/filters/http/common:pass_through_filter_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "http_header_processor_utils_lib",
+    srcs = ["utility.cc"],
+    hdrs = ["utility.h",],
     repository = "@envoy",
     deps = [
         ":pkg_cc_proto",

--- a/http-filter-example/BUILD
+++ b/http-filter-example/BUILD
@@ -62,7 +62,6 @@ envoy_cc_library(
     hdrs = ["utility.h",],
     repository = "@envoy",
     deps = [
-        ":pkg_cc_proto",
         "@envoy//source/extensions/filters/http/common:pass_through_filter_lib",
     ],
 )

--- a/http-filter-example/header_processor.cc
+++ b/http-filter-example/header_processor.cc
@@ -21,9 +21,14 @@ namespace SampleFilter {
         }
 
         // parse values and call setVals
-        std::vector<std::string> vals;
-        for (auto it = operation_expression.begin() + 3; it != operation_expression.end(); ++it) {
-            vals.push_back(std::string{*it});
+        try {
+            std::vector<std::string> vals;
+            for(auto it = operation_expression.begin() + 3; it != operation_expression.end(); ++it) { // could throw out of range
+                vals.push_back(std::string{*it}); // could through bad_alloc
+            }
+            setVals(vals);
+        } catch (const std::exception& e) {
+            return absl::InvalidArgumentError("error parsing header values");
         }
 
         // parse condition expression and call evaluate conditions on the parsed expression

--- a/http-filter-example/header_processor.cc
+++ b/http-filter-example/header_processor.cc
@@ -20,7 +20,7 @@ namespace SampleFilter {
 
         // parse values and call setVals
         std::vector<std::string> vals;
-        for(auto it = operation_expression.begin() + 3; it != operation_expression.end(); ++it) {
+        for (auto it = operation_expression.begin() + 3; it != operation_expression.end(); ++it) {
             vals.push_back(std::string{*it});
         }
         setVals(vals);

--- a/http-filter-example/http_filter.cc
+++ b/http-filter-example/http_filter.cc
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "http_filter.h"
+#include "utility.h"
 
 #include "source/common/common/utility.h"
 #include "source/common/common/logger.h"
@@ -34,24 +35,37 @@ HttpSampleDecoderFilter::HttpSampleDecoderFilter(HttpSampleDecoderFilterConfigSh
   // process each operation
   for (auto const& operation : operations) {
     auto tokens = StringUtil::splitToken(operation, " ");
-    if (tokens.size() < 3) {
+    if (tokens.size() < Utility::MIN_NUM_ARGUMENTS) {
       fail("too few arguments provided");
       setError();
       return; // TODO: should we quit here or continue to process operations that are grammatical?
     }
 
     // determine if it's request/response
-    if (tokens[0] != "http-request" && tokens[0] != "http-response") {
+    if (tokens.at(0) != Utility::HTTP_REQUEST && tokens.at(0) != Utility::HTTP_RESPONSE) {
       fail("first argument must be <http-response/http-request>");
       setError();
       return; // TODO: should we quit here or continue to process operations that are grammatical?
     }
-    const bool isRequest = (tokens[0] == "http-request");
+    const bool isRequest = (tokens.at(0) == "http-request");
 
-    // TODO: determine the operation type (right now I'm assuming that it's always a set-header operation)
+    Utility::OperationType operation_type = Utility::StringToOperationType(absl::string_view(tokens.at(1)));
+    HeaderProcessorUniquePtr processor;
 
-    // make new header processor
-    HeaderProcessorUniquePtr processor = std::make_unique<SetHeaderProcessor>();
+    switch(operation_type) {
+      case Utility::OperationType::kSetHeader:
+        // make new header processor
+        processor = std::make_unique<SetHeaderProcessor>();
+        break;
+      case Utility::OperationType::kSetPath:
+        // TODO: implement set-path operation
+        ENVOY_LOG_MISC(info, "set path operation detected!");
+        return;
+      default:
+        fail("invalid operation type");
+        setError(1); // TODO: change this to setError() once error checks PR is merged
+        return;
+    }
 
     // parse operation
     absl::Status status = processor->parseOperation(tokens);

--- a/http-filter-example/http_filter.cc
+++ b/http-filter-example/http_filter.cc
@@ -63,7 +63,7 @@ HttpSampleDecoderFilter::HttpSampleDecoderFilter(HttpSampleDecoderFilterConfigSh
         return;
       default:
         fail("invalid operation type");
-        setError(1); // TODO: change this to setError() once error checks PR is merged
+        setError(); // TODO: change this to setError() once error checks PR is merged
         return;
     }
 

--- a/http-filter-example/http_filter.cc
+++ b/http-filter-example/http_filter.cc
@@ -54,7 +54,6 @@ HttpSampleDecoderFilter::HttpSampleDecoderFilter(HttpSampleDecoderFilterConfigSh
 
     switch(operation_type) {
       case Utility::OperationType::kSetHeader:
-        // make new header processor
         processor = std::make_unique<SetHeaderProcessor>();
         break;
       case Utility::OperationType::kSetPath:
@@ -63,7 +62,7 @@ HttpSampleDecoderFilter::HttpSampleDecoderFilter(HttpSampleDecoderFilterConfigSh
         return;
       default:
         fail("invalid operation type");
-        setError(); // TODO: change this to setError() once error checks PR is merged
+        setError();
         return;
     }
 

--- a/http-filter-example/http_filter.cc
+++ b/http-filter-example/http_filter.cc
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "http_filter.h"
+#include "utility.h"
 
 #include "source/common/common/utility.h"
 #include "source/common/common/logger.h"
@@ -34,24 +35,37 @@ HttpSampleDecoderFilter::HttpSampleDecoderFilter(HttpSampleDecoderFilterConfigSh
   // process each operation
   for (auto const& operation : operations) {
     auto tokens = StringUtil::splitToken(operation, " ");
-    if (tokens.size() < 3) {
+    if (tokens.size() < Utility::MIN_NUM_ARGUMENTS) {
       fail("too few arguments provided");
       setError(1); // TODO: set error based on globally defined macros
       return;
     }
 
     // determine if it's request/response
-    if (tokens[0] != "http-request" && tokens[0] != "http-response") {
+    if (tokens.at(0) != Utility::HTTP_REQUEST && tokens.at(0) != Utility::HTTP_RESPONSE) {
       fail("first argument must be <http-response/http-request>");
       setError(1); // TODO: set error based on globally defined macros
       return;
     }
-    const bool isRequest = (tokens[0] == "http-request");
+    const bool isRequest = (tokens.at(0) == "http-request");
 
-    // TODO: determine the operation type (right now I'm assuming that it's always a set-header operation)
+    Utility::OperationType operation_type = Utility::StringToOperationType(absl::string_view(tokens.at(1)));
+    HeaderProcessorUniquePtr processor;
 
-    // make new header processor
-    HeaderProcessorUniquePtr processor = std::make_unique<SetHeaderProcessor>();
+    switch(operation_type) {
+      case Utility::OperationType::kSetHeader:
+        // make new header processor
+        processor = std::make_unique<SetHeaderProcessor>();
+        break;
+      case Utility::OperationType::kSetPath:
+        // TODO: implement set-path operation
+        ENVOY_LOG_MISC(info, "set path operation detected!");
+        return;
+      default:
+        fail("invalid operation type");
+        setError(1); // TODO: change this to setError() once error checks PR is merged
+        return;
+    }
 
     // parse operation
     if (processor->parseOperation(tokens)) {

--- a/http-filter-example/http_filter.cc
+++ b/http-filter-example/http_filter.cc
@@ -47,16 +47,16 @@ HttpSampleDecoderFilter::HttpSampleDecoderFilter(HttpSampleDecoderFilterConfigSh
       setError();
       return; // TODO: should we quit here or continue to process operations that are grammatical?
     }
-    const bool isRequest = (tokens.at(0) == "http-request");
+    const bool isRequest = (tokens.at(0) == Utility::HTTP_REQUEST);
 
-    Utility::OperationType operation_type = Utility::StringToOperationType(absl::string_view(tokens.at(1)));
+    const Utility::OperationType operation_type = Utility::StringToOperationType(absl::string_view(tokens.at(1)));
     HeaderProcessorUniquePtr processor;
 
     switch(operation_type) {
-      case Utility::OperationType::kSetHeader:
+      case Utility::OperationType::SetHeader:
         processor = std::make_unique<SetHeaderProcessor>();
         break;
-      case Utility::OperationType::kSetPath:
+      case Utility::OperationType::SetPath:
         // TODO: implement set-path operation
         ENVOY_LOG_MISC(info, "set path operation detected!");
         return;

--- a/http-filter-example/http_filter.cc
+++ b/http-filter-example/http_filter.cc
@@ -66,25 +66,6 @@ HttpSampleDecoderFilter::HttpSampleDecoderFilter(HttpSampleDecoderFilterConfigSh
         setError(); // TODO: change this to setError() once error checks PR is merged
         return;
     }
-    const bool isRequest = (tokens.at(0) == "http-request");
-
-    Utility::OperationType operation_type = Utility::StringToOperationType(absl::string_view(tokens.at(1)));
-    HeaderProcessorUniquePtr processor;
-
-    switch(operation_type) {
-      case Utility::OperationType::kSetHeader:
-        // make new header processor
-        processor = std::make_unique<SetHeaderProcessor>();
-        break;
-      case Utility::OperationType::kSetPath:
-        // TODO: implement set-path operation
-        ENVOY_LOG_MISC(info, "set path operation detected!");
-        return;
-      default:
-        fail("invalid operation type");
-        setError(); // TODO: change this to setError() once error checks PR is merged
-        return;
-    }
 
     // parse operation
     absl::Status status = processor->parseOperation(tokens);

--- a/http-filter-example/utility.cc
+++ b/http-filter-example/utility.cc
@@ -8,11 +8,11 @@ namespace Utility {
 
  OperationType StringToOperationType(absl::string_view operation) {
     if (operation == "set-header") {
-        return OperationType::kSetHeader;
+        return OperationType::SetHeader;
     } else if (operation == "set-path") {
-        return OperationType::kSetPath;
+        return OperationType::SetPath;
     } else {
-        return OperationType::kInvalidOperation;
+        return OperationType::InvalidOperation;
     }
 }
 

--- a/http-filter-example/utility.cc
+++ b/http-filter-example/utility.cc
@@ -1,0 +1,23 @@
+#include "utility.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace SampleFilter {
+namespace Utility {
+
+ OperationType StringToOperationType(absl::string_view operation) {
+    if (operation == "set-header") {
+        return OperationType::kSetHeader;
+    } else if (operation == "set-path") {
+        return OperationType::kSetPath;
+    } else {
+        return OperationType::kInvalidOperation;
+    }
+}
+
+} // namespace Utility
+} // namespace SampleFilter
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/http-filter-example/utility.h
+++ b/http-filter-example/utility.h
@@ -14,10 +14,9 @@ constexpr absl::string_view HTTP_REQUEST = "http-request";
 constexpr absl::string_view HTTP_RESPONSE = "http-response";
 
 enum class OperationType : int {
-  kSetHeader,
-  kSetPath,
-  NUM_OPERATIONS,
-  kInvalidOperation,
+  SetHeader,
+  SetPath,
+  InvalidOperation,
 };
 
 OperationType StringToOperationType(absl::string_view operation);

--- a/http-filter-example/utility.h
+++ b/http-filter-example/utility.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "absl/strings/string_view.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace SampleFilter {
+namespace Utility {
+
+constexpr uint8_t MIN_NUM_ARGUMENTS = 3;
+
+constexpr absl::string_view HTTP_REQUEST = "http-request";
+constexpr absl::string_view HTTP_RESPONSE = "http-response";
+
+enum class OperationType : int {
+  kSetHeader,
+  kSetPath,
+  NUM_OPERATIONS,
+  kInvalidOperation,
+};
+
+OperationType StringToOperationType(absl::string_view operation);
+
+} // namespace Utility
+} // namespace SampleFilter
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy


### PR DESCRIPTION
### Description
(See also: [EDGEBE-375])

This PR moves general constants into a utility file. 

See [this doc](https://datadoghq.atlassian.net/wiki/spaces/~712020ba1b13e5868d45e49dbc041828ac0041/blog/2023/06/30/3077636109/Building+Running+an+Envoy+Filter+Plugin) for documentation on building and running the envoy filter plugin.

### Testing
```
// Write a config for the filter
// Eg. "http-request set-header x-forwarded-proto https\n
//         http-request set-header mock_key mock_val1 mock_val2"

// Build and run envoy
bazel build //http-filter-example:envoy
./bazel-bin/http-filter-example/envoy -c ./http-filter-example/envoy-sample-config.yaml

// Set up Docker backend to echo http headers and send a curl request to envoy
// Docker image found here: https://hub.docker.com/r/ealen/echo-server
curl localhost:8081
```

We can see the specified headers have been added/modified:
```
ubuntu@ip-10-128-172-195:~$ curl localhost:8081
{"host":{"hostname":"localhost","ip":"::ffff:172.17.0.1","ips":[]},"http":{"method":"GET","baseUrl":"","originalUrl":"/","protocol":"http"},"request":{"params":{"0":"/"},"query":{},"cookies":{},"body":{},"headers":{"host":"localhost:8081","user-agent":"curl/7.68.0","accept":"*/*","x-forwarded-proto":"http,https","x-request-id":"8918d17d-a807-4619-ad06-d6ff39ad006b","mock_key":"mock_val1, mock_val2","x-envoy-expected-rq-timeout-ms":"15000"}},"environment":{"PATH":"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin","HOSTNAME":"e6cf43c557fd","NODE_VERSION":"16.16.0","YARN_VERSION":"1.22.19","HOME":"/root"}}
```
The code is able to detect multiple operations as well as invalid operations:

```
[2023-07-10 21:05:51.836][407011][info][config] [external/envoy/source/extensions/listener_managers/listener_manager/listener_manager_impl.cc:857] all dependencies initialized. starting workers
[2023-07-10 21:05:51.867][407011][info][main] [external/envoy/source/server/server.cc:937] starting main dispatch loop
[2023-07-10 21:05:53.547][407059][error][tracing] [http-filter-example/http_filter.cc:20] Failed to parse config - invalid operation type
```
```
[2023-07-10 21:05:39.934][406906][info][main] [external/envoy/source/server/server.cc:918] all clusters initialized. initializing init manager
[2023-07-10 21:05:39.934][406906][info][config] [external/envoy/source/extensions/listener_managers/listener_manager/listener_manager_impl.cc:857] all dependencies initialized. starting workers
[2023-07-10 21:05:39.966][406906][info][main] [external/envoy/source/server/server.cc:937] starting main dispatch loop
[2023-07-10 21:05:41.691][406930][info][misc] [http-filter-example/http_filter.cc:61] set path operation detected!
```
(Note: the set path operation still needs to be implemented)

[EDGEBE-375]: https://datadoghq.atlassian.net/browse/EDGEBE-375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ