### PR TITLE
changed filter base to be encoder/decoder

### DIFF
--- a/header-rewrite-filter/envoy-sample-config.yaml
+++ b/header-rewrite-filter/envoy-sample-config.yaml
@@ -43,11 +43,11 @@ static_resources:
           http_filters:
           - name: sample
             typed_config:
-              "@type": type.googleapis.com/sample.Decoder
+              "@type": type.googleapis.com/envoy.extensions.filters.http.HeaderRewrite
               key: header-processing
               val: |
                   http-request set-header x-forwarded-proto https
-                  http-request set-header mock_key mock_val1 mock_val2
+                  http-response set-header mock_key mock_val1 mock_val2
           - name: envoy.filters.http.router
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/header-rewrite-filter/header_processor.cc
+++ b/header-rewrite-filter/header_processor.cc
@@ -38,7 +38,7 @@ namespace HeaderRewriteFilter {
         return absl::OkStatus();
     }
 
-    void SetHeaderProcessor::executeOperation(Http::RequestHeaderMap& headers) const {
+    void SetHeaderProcessor::executeOperation(Http::RequestOrResponseHeaderMap& headers) const {
         bool condition_result = getCondition(); // whether the condition is true or false
         const std::string key = getKey();
         const std::vector<std::string>& header_vals = getVals();

--- a/header-rewrite-filter/header_processor.h
+++ b/header-rewrite-filter/header_processor.h
@@ -14,7 +14,7 @@ class HeaderProcessor {
 public:
   virtual ~HeaderProcessor() {};
   virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression) = 0;
-  virtual void executeOperation(Http::RequestHeaderMap& headers) const = 0;
+  virtual void executeOperation(Http::RequestOrResponseHeaderMap& headers) const = 0;
   virtual absl::Status evaluateCondition() = 0;
   bool getCondition() const { return condition_; }
   void setCondition(bool result) { condition_ = result; }
@@ -28,7 +28,7 @@ public:
   SetHeaderProcessor();
   virtual ~SetHeaderProcessor() {}
   virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression);
-  virtual void executeOperation(Http::RequestHeaderMap& headers) const;
+  virtual void executeOperation(Http::RequestOrResponseHeaderMap& headers) const;
   virtual absl::Status evaluateCondition(); // TODO: will need to pass http-related metadata in order to evaluate dynamic values
 
   // Note: the values returned by these functions must not outlive the SetHeaderProcessor object
@@ -37,10 +37,6 @@ public:
 
   void setKey(absl::string_view key) { header_key_ = std::string(key); }
   void setVals(std::vector<std::string> vals) { header_vals_ = vals; }
-
-  // TODO: should each operation store an error?
-  void setError() { error_ = true; }
-  bool getError() { return error_; }
 
 private:
   std::string header_key_; // header key to set

--- a/header-rewrite-filter/header_rewrite.h
+++ b/header-rewrite-filter/header_rewrite.h
@@ -16,7 +16,7 @@ namespace HeaderRewriteFilter {
 
 class HttpHeaderRewriteFilterConfig {
 public:
-  HttpHeaderRewriteFilterConfig(const sample::Decoder& proto_config);
+  HttpHeaderRewriteFilterConfig(const envoy::extensions::filters::http::HeaderRewrite& proto_config);
 
   const std::string& key() const { return key_; }
   const std::string& val() const { return val_; }
@@ -29,26 +29,25 @@ private:
 using HttpHeaderRewriteFilterConfigSharedPtr = std::shared_ptr<HttpHeaderRewriteFilterConfig>;
 using HeaderProcessorUniquePtr = std::unique_ptr<HeaderProcessor>;
 
-class HttpHeaderRewriteFilter : public Http::PassThroughDecoderFilter {
+class HttpHeaderRewriteFilter : public Http::PassThroughFilter {
 public:
   HttpHeaderRewriteFilter(HttpHeaderRewriteFilterConfigSharedPtr);
   virtual ~HttpHeaderRewriteFilter() {}
 
   void onDestroy() override {}
 
-  // Http::StreamDecoderFilter
   Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap&, bool) override;
   Http::FilterDataStatus decodeData(Buffer::Instance&, bool) override;
-  void setDecoderFilterCallbacks(Http::StreamDecoderFilterCallbacks&) override;
+  Http::FilterHeadersStatus encodeHeaders(Http::ResponseHeaderMap&, bool) override;
+  Http::FilterDataStatus encodeData(Buffer::Instance&, bool) override;
 
 private:
   const HttpHeaderRewriteFilterConfigSharedPtr config_;
-  Http::StreamDecoderFilterCallbacks* decoder_callbacks_;
   bool error_ = false;
 
   // header processors
-  // TODO: add one for response header processing once filter is converted to Encoder/Decoder
   std::vector<HeaderProcessorUniquePtr> request_header_processors_;
+  std::vector<HeaderProcessorUniquePtr> response_header_processors_;
 
   // set of accepted operations
   std::unordered_set<std::string> operations_;

--- a/header-rewrite-filter/header_rewrite.proto
+++ b/header-rewrite-filter/header_rewrite.proto
@@ -1,10 +1,10 @@
 syntax = "proto3";
 
-package sample;
+package envoy.extensions.filters.http;
 
 import "validate/validate.proto";
 
-message Decoder {
+message HeaderRewrite {
     string key = 1 [(validate.rules).string.min_len = 1];
     string val = 2 [(validate.rules).string.min_len = 1];
 }

--- a/header-rewrite-filter/header_rewrite_config.cc
+++ b/header-rewrite-filter/header_rewrite_config.cc
@@ -18,7 +18,7 @@ public:
                                                      const std::string&,
                                                      FactoryContext& context) override {
 
-    return createFilter(Envoy::MessageUtil::downcastAndValidate<const sample::Decoder&>(
+    return createFilter(Envoy::MessageUtil::downcastAndValidate<const envoy::extensions::filters::http::HeaderRewrite&>(
                             proto_config, context.messageValidationVisitor()),
                         context);
   }
@@ -27,20 +27,20 @@ public:
    *  Return the Protobuf Message that represents your config incase you have config proto
    */
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
-    return ProtobufTypes::MessagePtr{new sample::Decoder()};
+    return ProtobufTypes::MessagePtr{new envoy::extensions::filters::http::HeaderRewrite()};
   }
 
   std::string name() const override { return "sample"; }
 
 private:
-  Http::FilterFactoryCb createFilter(const sample::Decoder& proto_config, FactoryContext&) {
+  Http::FilterFactoryCb createFilter(const envoy::extensions::filters::http::HeaderRewrite& proto_config, FactoryContext&) {
     Extensions::HttpFilters::HeaderRewriteFilter::HttpHeaderRewriteFilterConfigSharedPtr config =
         std::make_shared<Extensions::HttpFilters::HeaderRewriteFilter::HttpHeaderRewriteFilterConfig>(
             Extensions::HttpFilters::HeaderRewriteFilter::HttpHeaderRewriteFilterConfig(proto_config));
 
     return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
       auto filter = new Extensions::HttpFilters::HeaderRewriteFilter::HttpHeaderRewriteFilter(config);
-      callbacks.addStreamDecoderFilter(Http::StreamDecoderFilterSharedPtr{filter});
+      callbacks.addStreamFilter(Http::StreamFilterSharedPtr{filter});
     };
   }
 };
@@ -54,3 +54,4 @@ static Registry::RegisterFactory<HttpHeaderRewriteFilterConfigFactory, NamedHttp
 } // namespace Configuration
 } // namespace Server
 } // namespace Envoy
+ 


### PR DESCRIPTION
### Description

This PR changes the header rewrite filter plugin to be active on both the request and response path (before this it was active only on the request path). 

See [this doc](https://datadoghq.atlassian.net/wiki/spaces/~712020ba1b13e5868d45e49dbc041828ac0041/blog/2023/06/30/3077636109/Building+Running+an+Envoy+Filter+Plugin) for documentation on building and running the envoy filter plugin.

### Testing
```
// Write a config for the filter
// Eg. "http-request set-header x-forwarded-proto https\n
//         http-response set-header mock_key mock_val1 mock_val2"
// Note: the above config is invalid, as the first operation is missing an argument

// Build and run envoy
bazel build //http-filter-example:envoy
./bazel-bin/http-filter-example/envoy -c ./http-filter-example/envoy-sample-config.yaml

// Set up Docker backend to echo http headers and send a curl request to envoy
// Docker image found here: https://hub.docker.com/r/ealen/echo-server
curl localhost:8081
```

We can see the operations performed on the request side:
```
ubuntu@ip-10-128-172-195:~$ curl localhost:8081
{"host":{"hostname":"localhost","ip":"::ffff:172.17.0.1","ips":[]},"http":{"method":"GET","baseUrl":"","originalUrl":"/","protocol":"http"},"request":{"params":{"0":"/"},"query":{},"cookies":{},"body":{},"headers":{"host":"localhost:8081","user-agent":"curl/7.68.0","accept":"*/*","x-forwarded-proto":"http,https","x-request-id":"7ec39314-0a9c-40a2-9eae-60e7f5dfaad9","x-envoy-expected-rq-timeout-ms":"15000"}},"environment":{"PATH":"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin","HOSTNAME":"e6cf43c557fd","NODE_VERSION":"16.16.0","YARN_VERSION":"1.22.19","HOME":"/root"}}
```
The response path is now also active:
```
[2023-07-11 20:29:29.977][516668][info][main] [external/envoy/source/server/server.cc:918] all clusters initialized. initializing init manager
[2023-07-11 20:29:29.977][516668][info][config] [external/envoy/source/extensions/listener_managers/listener_manager/listener_manager_impl.cc:857] all dependencies initialized. starting workers
[2023-07-11 20:29:30.007][516668][info][main] [external/envoy/source/server/server.cc:937] starting main dispatch loop
[2023-07-11 20:29:32.543][516697][info][misc] [header-rewrite-filter/header_rewrite.cc:116] added response header!
[2023-07-11 20:29:32.543][516697][info][misc] [header-rewrite-filter/header_rewrite.cc:128] encodeData
```

Verified that headers are being added to the response:
```
$ curl -v localhost:8081
*   Trying 127.0.0.1:8081...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8081 (#0)
> GET / HTTP/1.1
> Host: localhost:8081
> User-Agent: curl/7.68.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< x-envoy-upstream-service-time: 0
< mock_key: mock_val1
< mock_key: mock_val2
< date: Wed, 12 Jul 2023 13:58:20 GMT
< server: envoy
< transfer-encoding: chunked
```

Notes:
- I removed the request/response callback functions from the filter as they currently don't do anything
- Using `envoy::extensions::filters::http::HeaderRewrite` namespace for filter protobuf as this is the namespace that Lua filter uses, but am open to suggestions if there's a better namespace to use!