### PR TITLE
implemented set-path operation

### DIFF
--- a/header-rewrite-filter/envoy-sample-config.yaml
+++ b/header-rewrite-filter/envoy-sample-config.yaml
@@ -46,6 +46,7 @@ static_resources:
               "@type": type.googleapis.com/envoy.extensions.filters.http.HeaderRewrite
               key: header-processing
               val: |
+                  http-request set-path mockpath
                   http-request set-header x-forwarded-proto https
                   http-response set-header mock_key mock_val1 mock_val2
           - name: envoy.filters.http.router

--- a/header-rewrite-filter/header_processor.cc
+++ b/header-rewrite-filter/header_processor.cc
@@ -91,7 +91,7 @@ namespace HeaderRewriteFilter {
         // cast to RequestHeaderMap because setPath is only on request side
         Http::RequestHeaderMap* request_headers = static_cast<Http::RequestHeaderMap*>(&headers);
         
-        // set path
+        // set path (path being set here includes the query string)
         request_headers->setPath(request_path); // should never return an error
     }
 

--- a/header-rewrite-filter/header_processor.cc
+++ b/header-rewrite-filter/header_processor.cc
@@ -13,7 +13,7 @@ namespace HeaderRewriteFilter {
 
         // parse key and call setKey
         try {
-            absl::string_view key = operation_expression.at(2);
+            const absl::string_view key = operation_expression.at(2);
             setKey(key);
         } catch (const std::exception& e) {
             // should never happen, range is checked above
@@ -32,7 +32,7 @@ namespace HeaderRewriteFilter {
         }
 
         // parse condition expression and call evaluate conditions on the parsed expression
-        absl::Status status = evaluateCondition();
+        const absl::Status status = evaluateCondition();
         return status;
     }
 
@@ -76,12 +76,12 @@ namespace HeaderRewriteFilter {
         }
 
         // parse condition expression and call evaluate conditions on the parsed expression
-        absl::Status status = evaluateCondition();
+        const absl::Status status = evaluateCondition();
         return status;
     }
 
     void SetPathProcessor::executeOperation(Http::RequestOrResponseHeaderMap& headers) const {
-        bool condition_result = getCondition(); // whether the condition is true or false
+        const bool condition_result = getCondition(); // whether the condition is true or false
         const std::string request_path = getPath();
 
         if (!condition_result) {

--- a/header-rewrite-filter/header_processor.h
+++ b/header-rewrite-filter/header_processor.h
@@ -12,7 +12,7 @@ namespace HeaderRewriteFilter {
 
 class HeaderProcessor {
 public:
-  virtual ~HeaderProcessor() {};
+  virtual ~HeaderProcessor() {}
   virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression) = 0;
   virtual void executeOperation(Http::RequestOrResponseHeaderMap& headers) const = 0;
   virtual absl::Status evaluateCondition() = 0;
@@ -25,12 +25,13 @@ protected:
 
 class SetHeaderProcessor : public HeaderProcessor {
 public:
-  SetHeaderProcessor();
+  SetHeaderProcessor() {}
   virtual ~SetHeaderProcessor() {}
   virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression);
   virtual void executeOperation(Http::RequestOrResponseHeaderMap& headers) const;
   virtual absl::Status evaluateCondition(); // TODO: will need to pass http-related metadata in order to evaluate dynamic values
 
+private:
   // Note: the values returned by these functions must not outlive the SetHeaderProcessor object
   const std::string& getKey() const { return header_key_; }
   const std::vector<std::string>& getVals() const { return header_vals_; }
@@ -38,10 +39,23 @@ public:
   void setKey(absl::string_view key) { header_key_ = std::string(key); }
   void setVals(std::vector<std::string> vals) { header_vals_ = vals; }
 
-private:
   std::string header_key_; // header key to set
   std::vector<std::string> header_vals_; // header values to set
-  bool error_ = false;
+};
+
+class SetPathProcessor : public HeaderProcessor {
+public:
+  SetPathProcessor() {}
+  virtual ~SetPathProcessor() {}
+  virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression);
+  virtual void executeOperation(Http::RequestOrResponseHeaderMap& headers) const;
+  virtual absl::Status evaluateCondition(); // TODO: possibly combine with SetHeader implementation and move code into HeaderProcessor
+
+private:
+  const std::string& getPath() const { return request_path_; }
+  void setPath(absl::string_view path) { request_path_ = std::string(path); }
+
+  std::string request_path_; // path to set
 };
 
 } // namespace HeaderRewriteFilter

--- a/header-rewrite-filter/header_processor.h
+++ b/header-rewrite-filter/header_processor.h
@@ -43,6 +43,7 @@ private:
   std::vector<std::string> header_vals_; // header values to set
 };
 
+// Note: path being set here includes the query string
 class SetPathProcessor : public HeaderProcessor {
 public:
   SetPathProcessor() {}

--- a/header-rewrite-filter/header_rewrite.cc
+++ b/header-rewrite-filter/header_rewrite.cc
@@ -57,9 +57,13 @@ HttpHeaderRewriteFilter::HttpHeaderRewriteFilter(HttpHeaderRewriteFilterConfigSh
         processor = std::make_unique<SetHeaderProcessor>();
         break;
       case Utility::OperationType::SetPath:
-        // TODO: implement set-path operation
-        ENVOY_LOG_MISC(info, "set path operation detected!");
-        return;
+        if (!isRequest) {
+          fail("set-path can only be on request");
+          setError();
+          return;
+        }
+        processor = std::make_unique<SetPathProcessor>();
+        break;
       default:
         fail("invalid operation type");
         setError();
@@ -113,8 +117,8 @@ Http::FilterHeadersStatus HttpHeaderRewriteFilter::encodeHeaders(Http::ResponseH
 
   // execute each operation
   for (auto const& processor : response_header_processors_) {
-    ENVOY_LOG_MISC(info, "added response header!"); // TODO: remove debug statement once response-side test setup is created
     processor->executeOperation(headers);
+    ENVOY_LOG_MISC(info, "added response header!"); // TODO: remove debug statement once response-side test setup is created
   }
 
   return Http::FilterHeadersStatus::Continue;
@@ -125,7 +129,7 @@ Http::FilterDataStatus HttpHeaderRewriteFilter::decodeData(Buffer::Instance&, bo
 }
 
 Http::FilterDataStatus HttpHeaderRewriteFilter::encodeData(Buffer::Instance&, bool) {
-  ENVOY_LOG_MISC(info, "encodeData"); // TODO: remove debug statement once response-side test setup is created
+  ENVOY_LOG_MISC(info, "encodeData function called"); // TODO: remove debug statement once response-side test setup is created
   return Http::FilterDataStatus::Continue;
 }
 

--- a/header-rewrite-filter/header_rewrite.cc
+++ b/header-rewrite-filter/header_rewrite.cc
@@ -62,6 +62,7 @@ HttpHeaderRewriteFilter::HttpHeaderRewriteFilter(HttpHeaderRewriteFilterConfigSh
           setError();
           return;
         }
+        // path being set here includes the query string
         processor = std::make_unique<SetPathProcessor>();
         break;
       default:

--- a/header-rewrite-filter/utility.h
+++ b/header-rewrite-filter/utility.h
@@ -8,7 +8,9 @@ namespace HttpFilters {
 namespace HeaderRewriteFilter {
 namespace Utility {
 
-constexpr uint8_t MIN_NUM_ARGUMENTS = 4;
+constexpr uint8_t MIN_NUM_ARGUMENTS = 2;
+constexpr uint8_t SET_HEADER_MIN_NUM_ARGUMENTS = 4;
+constexpr uint8_t SET_PATH_MIN_NUM_ARGUMENTS = 3;
 
 constexpr absl::string_view HTTP_REQUEST = "http-request";
 constexpr absl::string_view HTTP_RESPONSE = "http-response";


### PR DESCRIPTION
### Description

This PR implements the HTTP request set path operation. 

See [this doc](https://datadoghq.atlassian.net/wiki/spaces/~712020ba1b13e5868d45e49dbc041828ac0041/blog/2023/06/30/3077636109/Building+Running+an+Envoy+Filter+Plugin) for documentation on building and running the envoy filter plugin.

### Testing
```
// Write a config for the filter
// Eg. "http-request set-header x-forwarded-proto https\n
//         http-response set-header mock_key mock_val1 mock_val2
//         http-request set-path mockpath"

// Build and run envoy
bazel build //http-filter-example:envoy
./bazel-bin/http-filter-example/envoy -c ./http-filter-example/envoy-sample-config.yaml

// Set up Docker backend to echo http headers and send a curl request to envoy
// Docker image found here: https://hub.docker.com/r/ealen/echo-server
curl localhost:8081
```

We can see the path has changed:
```
$ while true; do printf 'HTTP/1.1 200 OK\r\n\r\n' | nc -Nl 8000; done
GET mockpath HTTP/1.1
host: localhost:8081
user-agent: curl/7.68.0
accept: */*
x-forwarded-proto: http,https
x-request-id: 1c228096-f71d-4d6a-b25a-f726abc6df6d
x-envoy-expected-rq-timeout-ms: 15000
```