### PR TITLE
Implement bool vars

### DIFF
--- a/header-rewrite-filter/envoy-sample-config.yaml
+++ b/header-rewrite-filter/envoy-sample-config.yaml
@@ -46,6 +46,7 @@ static_resources:
               "@type": type.googleapis.com/envoy.extensions.filters.http.HeaderRewrite
               key: header-processing
               val: |
+                  http set-bool mock_bool matches -m str matches
                   http-request set-path mockpath
                   http-request set-header x-forwarded-proto https
                   http-response set-header mock_key mock_val1 mock_val2
@@ -71,4 +72,4 @@ static_resources:
             address:
               socket_address:
                 address: 127.0.0.1
-                port_value: 3000 # connected to dummy docker backend
+                port_value: 8000 # connected to dummy docker backend

--- a/header-rewrite-filter/header_processor.cc
+++ b/header-rewrite-filter/header_processor.cc
@@ -1,5 +1,4 @@
 #include "header_processor.h"
-#include "utility.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -41,7 +40,7 @@ namespace HeaderRewriteFilter {
         return absl::OkStatus();
     }
 
-    void SetHeaderProcessor::executeOperation(Http::RequestOrResponseHeaderMap& headers) const {
+    void SetHeaderProcessor::executeOperation(Http::RequestOrResponseHeaderMap& headers) {
         bool condition_result = getCondition(); // whether the condition is true or false
         const std::string key = getKey();
         const std::vector<std::string>& header_vals = getVals();
@@ -80,7 +79,7 @@ namespace HeaderRewriteFilter {
         return status;
     }
 
-    void SetPathProcessor::executeOperation(Http::RequestOrResponseHeaderMap& headers) const {
+    void SetPathProcessor::executeOperation(Http::RequestOrResponseHeaderMap& headers) {
         const bool condition_result = getCondition(); // whether the condition is true or false
         const std::string request_path = getPath();
 
@@ -91,9 +90,74 @@ namespace HeaderRewriteFilter {
         // cast to RequestHeaderMap because setPath is only on request side
         Http::RequestHeaderMap* request_headers = static_cast<Http::RequestHeaderMap*>(&headers);
         
-        // set path
+        // set path (path being set here includes the query string)
         request_headers->setPath(request_path); // should never return an error
     }
+
+
+    void SetBoolProcessor::setStringsToCompare(std::pair<absl::string_view, absl::string_view> strings_to_compare) {
+        std::string first_string(strings_to_compare.first);
+        std::string second_string(strings_to_compare.second);
+
+        strings_to_compare_ = std::make_pair(first_string, second_string); 
+    }
+
+    absl::Status SetBoolProcessor::parseOperation(std::vector<absl::string_view>& operation_expression) {
+        if (operation_expression.size() < Utility::SET_BOOL_MIN_NUM_ARGUMENTS) {
+            return absl::InvalidArgumentError("not enough arguments for set-bool");
+        }
+
+        try {
+            absl::string_view bool_name = operation_expression.at(2);
+            setBoolName(bool_name);
+
+            if (operation_expression.at(4) != "-m") {
+                return absl::InvalidArgumentError("invalid match syntax");
+            }
+
+            const Utility::MatchType match_type = Utility::StringToMatchType(operation_expression.at(5));
+
+            switch (match_type) {
+                case Utility::MatchType::Exact:
+                    {
+                        std::pair<absl::string_view, absl::string_view> strings_to_compare(operation_expression.at(3), operation_expression.at(6));
+                        setStringsToCompare(strings_to_compare);
+                        break;
+                    }
+                // TODO: implement this
+                case Utility::MatchType::Substr:
+                    break;
+                case Utility::MatchType::Found:
+                    break;
+                default:
+                    return absl::InvalidArgumentError("invalid match type");
+            }
+
+        } catch (const std::exception& e) {
+            // should never happen, range is checked above
+            return absl::InvalidArgumentError("error parsing request path argument");
+        }
+
+        return absl::OkStatus();
+    }
+
+    void SetBoolProcessor::executeOperation(Http::RequestOrResponseHeaderMap& headers) {
+        const Utility::MatchType match_type = getMatchType();
+
+        bool result;
+
+        switch (match_type) {
+            case Utility::MatchType::Exact:
+                result = (getStringsToCompare().first == getStringsToCompare().second);
+                break;
+            // TODO: implement rest of the match cases
+            default:
+                result = false;
+        }
+
+        result_ = result;
+    }
+
 
 } // namespace HeaderRewriteFilter
 } // namespace HttpFilters

--- a/header-rewrite-filter/header_processor.h
+++ b/header-rewrite-filter/header_processor.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "utility.h"
+
 #include "source/extensions/filters/http/common/pass_through_filter.h"
 
 #include <string>
@@ -10,12 +12,17 @@ namespace Extensions {
 namespace HttpFilters {
 namespace HeaderRewriteFilter {
 
-class HeaderProcessor {
+class Processor {
+public:
+  virtual ~Processor() {}
+  virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression) { return absl::OkStatus(); }
+  virtual void executeOperation(Http::RequestOrResponseHeaderMap& headers) { }
+};
+
+class HeaderProcessor : public Processor {
 public:
   virtual ~HeaderProcessor() {}
-  virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression) = 0;
-  virtual void executeOperation(Http::RequestOrResponseHeaderMap& headers) const = 0;
-  virtual absl::Status evaluateCondition() = 0;
+  virtual absl::Status evaluateCondition() { return absl::OkStatus(); }
   bool getCondition() const { return condition_; }
   void setCondition(bool result) { condition_ = result; }
 
@@ -28,7 +35,7 @@ public:
   SetHeaderProcessor() {}
   virtual ~SetHeaderProcessor() {}
   virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression);
-  virtual void executeOperation(Http::RequestOrResponseHeaderMap& headers) const;
+  virtual void executeOperation(Http::RequestOrResponseHeaderMap& headers);
   virtual absl::Status evaluateCondition(); // TODO: will need to pass http-related metadata in order to evaluate dynamic values
 
 private:
@@ -43,12 +50,13 @@ private:
   std::vector<std::string> header_vals_; // header values to set
 };
 
+// Note: path being set here includes the query string
 class SetPathProcessor : public HeaderProcessor {
 public:
   SetPathProcessor() {}
   virtual ~SetPathProcessor() {}
   virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression);
-  virtual void executeOperation(Http::RequestOrResponseHeaderMap& headers) const;
+  virtual void executeOperation(Http::RequestOrResponseHeaderMap& headers);
   virtual absl::Status evaluateCondition(); // TODO: possibly combine with SetHeader implementation and move code into HeaderProcessor
 
 private:
@@ -56,6 +64,29 @@ private:
   void setPath(absl::string_view path) { request_path_ = std::string(path); }
 
   std::string request_path_; // path to set
+};
+
+class SetBoolProcessor : public Processor {
+public:
+  virtual ~SetBoolProcessor() {}
+  virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression);
+  virtual void executeOperation(Http::RequestOrResponseHeaderMap& headers);
+  const std::string& getBoolName() const { return bool_name_; }
+  const bool getResult() const { return result_; }
+
+private:
+  void setBoolName(absl::string_view bool_name) { bool_name_ = std::string(bool_name); }
+
+  const std::pair<std::string, std::string>& getStringsToCompare() const { return strings_to_compare_; }
+  void setStringsToCompare(std::pair<absl::string_view, absl::string_view> strings_to_compare);
+
+  Utility::MatchType getMatchType() const { return match_type_; }
+  void setMatchType(Utility::MatchType match_type) { match_type_ = match_type; }
+
+  std::string bool_name_; // TODO: might only need to store this in the map
+  std::pair<std::string, std::string> strings_to_compare_;
+  Utility::MatchType match_type_;
+  bool result_;
 };
 
 } // namespace HeaderRewriteFilter

--- a/header-rewrite-filter/header_rewrite.h
+++ b/header-rewrite-filter/header_rewrite.h
@@ -27,7 +27,9 @@ private:
 };
 
 using HttpHeaderRewriteFilterConfigSharedPtr = std::shared_ptr<HttpHeaderRewriteFilterConfig>;
+using ProcessorUniquePtr = std::unique_ptr<Processor>;
 using HeaderProcessorUniquePtr = std::unique_ptr<HeaderProcessor>;
+using SetBoolProcessorUniquePtr = std::unique_ptr<SetBoolProcessor>;
 
 class HttpHeaderRewriteFilter : public Http::PassThroughFilter {
 public:
@@ -46,11 +48,11 @@ private:
   bool error_ = false;
 
   // header processors
-  std::vector<HeaderProcessorUniquePtr> request_header_processors_;
-  std::vector<HeaderProcessorUniquePtr> response_header_processors_;
+  std::vector<ProcessorUniquePtr> request_header_processors_;
+  std::vector<ProcessorUniquePtr> response_header_processors_;
 
-  // set of accepted operations
-  std::unordered_set<std::string> operations_;
+  // set_bool processors
+  std::unordered_map<std::string, ProcessorUniquePtr> set_bool_processors_;
 
   const Http::LowerCaseString headerKey() const;
   const std::string headerValue() const;

--- a/header-rewrite-filter/utility.cc
+++ b/header-rewrite-filter/utility.cc
@@ -11,8 +11,22 @@ namespace Utility {
         return OperationType::SetHeader;
     } else if (operation == "set-path") {
         return OperationType::SetPath;
+    } else if (operation == "set-bool") {
+        return OperationType::SetBool;
     } else {
         return OperationType::InvalidOperation;
+    }
+}
+
+MatchType StringToMatchType(absl::string_view match) {
+   if (match == MATCH_TYPE_EXACT) {
+        return MatchType::Exact;
+    } else if (match == MATCH_TYPE_SUBSTR) {
+        return MatchType::Substr;
+    } else if (match == MATCH_TYPE_FOUND) {
+        return MatchType::Found;
+    } else {
+        return MatchType::InvalidMatchType;
     }
 }
 

--- a/header-rewrite-filter/utility.h
+++ b/header-rewrite-filter/utility.h
@@ -11,17 +11,32 @@ namespace Utility {
 constexpr uint8_t MIN_NUM_ARGUMENTS = 2;
 constexpr uint8_t SET_HEADER_MIN_NUM_ARGUMENTS = 4;
 constexpr uint8_t SET_PATH_MIN_NUM_ARGUMENTS = 3;
+constexpr uint8_t SET_BOOL_MIN_NUM_ARGUMENTS = 6;
 
 constexpr absl::string_view HTTP_REQUEST = "http-request";
 constexpr absl::string_view HTTP_RESPONSE = "http-response";
+constexpr absl::string_view HTTP_REQUEST_RESPONSE = "http";
+
+constexpr absl::string_view MATCH_TYPE_EXACT = "str";
+constexpr absl::string_view MATCH_TYPE_SUBSTR = "sub";
+constexpr absl::string_view MATCH_TYPE_FOUND = "found";
 
 enum class OperationType : int {
   SetHeader,
   SetPath,
+  SetBool,
   InvalidOperation,
 };
 
+enum class MatchType : int {
+  Exact,
+  Substr,
+  Found,
+  InvalidMatchType,
+};
+
 OperationType StringToOperationType(absl::string_view operation);
+MatchType StringToMatchType(absl::string_view match);
 
 } // namespace Utility
 } // namespace HeaderRewriteFilter


### PR DESCRIPTION
### Description

This PR implements setting boolean variables in the envoy config. 

Usage:
`http set-bool <name of bool> <constant value> -m <type of match> <optional args>`

See [this doc](https://datadoghq.atlassian.net/wiki/spaces/~712020ba1b13e5868d45e49dbc041828ac0041/blog/2023/06/30/3077636109/Building+Running+an+Envoy+Filter+Plugin) for documentation on building and running the envoy filter plugin.

### Testing
```
// Write a config for the filter
// Eg. "http set-bool mock_bool matches -m str matches
                  http-request set-path mockpath
                  http-request set-header x-forwarded-proto https
                  http-response set-header mock_key mock_val1 mock_val2"

// Build and run envoy
bazel build //http-filter-example:envoy
./bazel-bin/http-filter-example/envoy -c ./http-filter-example/envoy-sample-config.yaml

// Set up Docker backend to echo http headers and send a curl request to envoy
// Docker image found here: https://hub.docker.com/r/ealen/echo-server
curl localhost:8081
```

Request looks like this:
```
GET mockpath HTTP/1.1
host: localhost:8081
user-agent: curl/7.68.0
accept: */*
x-forwarded-proto: http,https
x-request-id: 6455c017-01dc-41c3-8c34-fc289c2cefa9
x-envoy-expected-rq-timeout-ms: 15000
```

Response looks like this:
```
$ curl -v localhost:8081
*   Trying 127.0.0.1:8081...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8081 (#0)
> GET / HTTP/1.1
> Host: localhost:8081
> User-Agent: curl/7.68.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< x-envoy-upstream-service-time: 0
< mock_key: mock_val1
< mock_key: mock_val2
< date: Wed, 12 Jul 2023 20:17:36 GMT
< server: envoy
< transfer-encoding: chunked
```

Added a debug statement ("match found!") for when the boolean variable evaluates to true. We can see in the logs that the boolean expression has indeed evaluated to true:
```
[2023-07-12 20:17:34.544][619806][info][upstream] [external/envoy/source/common/upstream/cluster_manager_impl.cc:226] cm init: all clusters initialized
[2023-07-12 20:17:34.544][619806][warning][main] [external/envoy/source/server/server.cc:811] there is no configured limit to the number of allowed active connections. Set a limit via the runtime key overload.global_downstream_max_connections
[2023-07-12 20:17:34.545][619806][info][main] [external/envoy/source/server/server.cc:918] all clusters initialized. initializing init manager
[2023-07-12 20:17:34.545][619806][info][config] [external/envoy/source/extensions/listener_managers/listener_manager/listener_manager_impl.cc:857] all dependencies initialized. starting workers
[2023-07-12 20:17:34.577][619806][info][main] [external/envoy/source/server/server.cc:937] starting main dispatch loop
[2023-07-12 20:17:36.406][619844][info][misc] [header-rewrite-filter/header_rewrite.cc:138] added response header!
[2023-07-12 20:17:36.406][619844][info][misc] [header-rewrite-filter/header_rewrite.cc:143] match found!
[2023-07-12 20:17:36.406][619844][info][misc] [header-rewrite-filter/header_rewrite.cc:153] encodeData function called
```

Next steps:
- Evaluate a conditional consisting of boolean expressions
- Add support for dynamic values in boolean expressions