### PR TITLE
modified integration tests for new filter setup

### DIFF
--- a/header-rewrite-filter/header_processor.cc
+++ b/header-rewrite-filter/header_processor.cc
@@ -51,7 +51,7 @@ namespace HeaderRewriteFilter {
         
         // set header
         for (auto const& header_val : header_vals) {
-            headers.addCopy(Http::LowerCaseString(key), header_val); // should never return an error
+            headers.setCopy(Http::LowerCaseString(key), header_val); // should never return an error
         }
     }
 

--- a/header-rewrite-filter/header_processor.cc
+++ b/header-rewrite-filter/header_processor.cc
@@ -51,7 +51,7 @@ namespace HeaderRewriteFilter {
         
         // set header
         for (auto const& header_val : header_vals) {
-            headers.setCopy(Http::LowerCaseString(key), header_val); // should never return an error
+            headers.appendCopy(Http::LowerCaseString(key), header_val); // should never return an error
         }
     }
 

--- a/header-rewrite-filter/header_rewrite_integration_test.cc
+++ b/header-rewrite-filter/header_rewrite_integration_test.cc
@@ -9,16 +9,10 @@ public:
   /**
    * Initializer for an individual integration test.
    */
-  void SetUp() override { }
+  void SetUp() override {}
   void SetUp(std::string config) { initialize(config); }
 
-  void initialize() override {
-    config_helper_.prependFilter(
-        "{ name: sample, typed_config: { \"@type\": type.googleapis.com/sample.Decoder, key: via, "
-        "val: sample-filter } }");
-    HttpIntegrationTest::initialize();
-  }
-
+  void initialize() override {}
   void initialize(std::string config) {
     config_helper_.prependFilter(config);
     HttpIntegrationTest::initialize();

--- a/header-rewrite-filter/header_rewrite_integration_test.cc
+++ b/header-rewrite-filter/header_rewrite_integration_test.cc
@@ -25,7 +25,7 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, HttpFilterHeaderRewriteIntegrationTest,
 
 TEST_P(HttpFilterHeaderRewriteIntegrationTest, Test1) {
   SetUp("{ name: sample, typed_config: { \"@type\": type.googleapis.com/envoy.extensions.filters.http.HeaderRewrite, key: header-processing,"
-    "val: http-request set-header x-forwarded-proto https } }");
+    "val: http-request set-header sample_header sample_value } }");
   Http::TestRequestHeaderMapImpl headers{
       {":method", "GET"}, {":path", "/"}, {":authority", "host"}};
   Http::TestRequestHeaderMapImpl response_headers{
@@ -44,8 +44,8 @@ TEST_P(HttpFilterHeaderRewriteIntegrationTest, Test1) {
   ASSERT_TRUE(response->waitForEndStream());
 
   EXPECT_EQ(
-      "http,https",
-      request_stream->headers().get(Http::LowerCaseString("x-forwarded-proto"))[0]->value().getStringView());
+      "sample_value",
+      request_stream->headers().get(Http::LowerCaseString("sample_header"))[0]->value().getStringView());
 
   codec_client->close();
 }

--- a/header-rewrite-filter/header_rewrite_integration_test.cc
+++ b/header-rewrite-filter/header_rewrite_integration_test.cc
@@ -9,7 +9,8 @@ public:
   /**
    * Initializer for an individual integration test.
    */
-  void SetUp() override { initialize(); }
+  void SetUp() override { }
+  void SetUp(std::string config) { initialize(config); }
 
   void initialize() override {
     config_helper_.prependFilter(
@@ -17,12 +18,20 @@ public:
         "val: sample-filter } }");
     HttpIntegrationTest::initialize();
   }
+
+  void initialize(std::string config) {
+    config_helper_.prependFilter(config);
+    HttpIntegrationTest::initialize();
+  }
+
 };
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, HttpFilterHeaderRewriteIntegrationTest,
                          testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
 
 TEST_P(HttpFilterHeaderRewriteIntegrationTest, Test1) {
+  SetUp("{ name: sample, typed_config: { \"@type\": type.googleapis.com/envoy.extensions.filters.http.HeaderRewrite, key: header-processing,"
+    "val: http-request set-header x-forwarded-proto https } }");
   Http::TestRequestHeaderMapImpl headers{
       {":method", "GET"}, {":path", "/"}, {":authority", "host"}};
   Http::TestRequestHeaderMapImpl response_headers{
@@ -41,8 +50,8 @@ TEST_P(HttpFilterHeaderRewriteIntegrationTest, Test1) {
   ASSERT_TRUE(response->waitForEndStream());
 
   EXPECT_EQ(
-      "sample-filter",
-      request_stream->headers().get(Http::LowerCaseString("via"))[0]->value().getStringView());
+      "http,https",
+      request_stream->headers().get(Http::LowerCaseString("x-forwarded-proto"))[0]->value().getStringView());
 
   codec_client->close();
 }


### PR DESCRIPTION
Modified integration tests for header rewrite filter. This test checks the result of a simple set-header operation. More tests will be added in the future.

Test output:
```
$ bazel test //header-rewrite-filter:header_rewrite_integration_test
INFO: Analyzed target //header-rewrite-filter:header_rewrite_integration_test (0 packages loaded, 0 targets configured).
INFO: Found 1 test target...
Target //header-rewrite-filter:header_rewrite_integration_test up-to-date:
  bazel-bin/header-rewrite-filter/header_rewrite_integration_test
INFO: Elapsed time: 80.687s, Critical Path: 80.26s
INFO: 4 processes: 1 internal, 3 linux-sandbox.
INFO: Build completed successfully, 4 total actions

Executed 1 out of 1 test: 1 test passes.
```