### PR TITLE
Implement conditions with mock boolean values

### DIFF
--- a/header-rewrite-filter/BUILD
+++ b/header-rewrite-filter/BUILD
@@ -52,6 +52,7 @@ envoy_cc_library(
     deps = [
         ":pkg_cc_proto",
         ":header_rewrite_utils_lib",
+        "@envoy//source/common/common:minimal_logger_lib",
         "@envoy//source/extensions/filters/http/common:pass_through_filter_lib",
     ],
 )

--- a/header-rewrite-filter/envoy-sample-config.yaml
+++ b/header-rewrite-filter/envoy-sample-config.yaml
@@ -47,9 +47,9 @@ static_resources:
               key: header-processing
               val: |
                   http set-bool mock_bool matches -m str matches
-                  http-request set-path mockpath
-                  http-request set-header x-forwarded-proto https
-                  http-response set-header mock_key mock_val1 mock_val2
+                  http-request set-path mockpath if not A
+                  http-request set-header x-forwarded-proto https if A and B and C
+                  http-response set-header mock_key mock_val1 mock_val2 if not A
           - name: envoy.filters.http.router
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/header-rewrite-filter/header_processor.cc
+++ b/header-rewrite-filter/header_processor.cc
@@ -1,18 +1,23 @@
 #include "header_processor.h"
 
+#include "source/common/common/logger.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
 namespace HeaderRewriteFilter {
 
-    absl::Status SetHeaderProcessor::parseOperation(std::vector<absl::string_view>& operation_expression) {
+    absl::Status SetHeaderProcessor::parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start) {
         if (operation_expression.size() < Utility::SET_HEADER_MIN_NUM_ARGUMENTS) {
             return absl::InvalidArgumentError("not enough arguments for set-header");
         }
 
+        // TODO: remove
+        start++;
+
         // parse key and call setKey
         try {
-            const absl::string_view key = operation_expression.at(2);
+            const absl::string_view key = operation_expression.at(2); // TODO: use start
             setKey(key);
         } catch (const std::exception& e) {
             // should never happen, range is checked above
@@ -23,6 +28,15 @@ namespace HeaderRewriteFilter {
         try {
             std::vector<std::string> vals;
             for(auto it = operation_expression.begin() + 3; it != operation_expression.end(); ++it) {
+                if (*it == "if") { // condition found
+
+                    const absl::Status status = HeaderProcessor::ConditionProcessorSetup(operation_expression, it+1); // pass everything after the "if"
+
+                    if (status != absl::OkStatus()) {
+                        return status;
+                    }
+                    break;
+                }
                 vals.push_back(std::string{*it}); // could throw bad_alloc
             }
             setVals(vals);
@@ -30,17 +44,31 @@ namespace HeaderRewriteFilter {
             return absl::InvalidArgumentError("error parsing header values");
         }
 
-        // parse condition expression and call evaluate conditions on the parsed expression
-        const absl::Status status = evaluateCondition();
-        return status;
-    }
-
-    absl::Status SetHeaderProcessor::evaluateCondition() {
-        setCondition(true);
         return absl::OkStatus();
     }
 
+    absl::Status HeaderProcessor::evaluateCondition() {
+        // call ConditionProcessor executeOperation; if it is null, return true
+        bool result = true;
+        if (getConditionProcessor()) {
+            result = getConditionProcessor()->executeOperation();
+        }
+        setCondition(result);
+
+        return absl::OkStatus();
+    }
+
+    absl::Status HeaderProcessor::ConditionProcessorSetup(std::vector<absl::string_view>& condition_expression, std::vector<absl::string_view>::iterator start) {
+        if (start == condition_expression.end()) {
+            return absl::InvalidArgumentError("empty condition provided");
+        }
+
+        setConditionProcessor(std::make_shared<ConditionProcessor>());
+        return getConditionProcessor()->parseOperation(condition_expression, start); // pass everything after the "if"
+    }
+
     void SetHeaderProcessor::executeOperation(Http::RequestOrResponseHeaderMap& headers) {
+        evaluateCondition();
         bool condition_result = getCondition(); // whether the condition is true or false
         const std::string key = getKey();
         const std::vector<std::string>& header_vals = getVals();
@@ -55,31 +83,41 @@ namespace HeaderRewriteFilter {
         }
     }
 
-     absl::Status SetPathProcessor::evaluateCondition() {
-        setCondition(true);
-        return absl::OkStatus();
-    }
-
-    absl::Status SetPathProcessor::parseOperation(std::vector<absl::string_view>& operation_expression) {
+    absl::Status SetPathProcessor::parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start) {
         if (operation_expression.size() < Utility::SET_PATH_MIN_NUM_ARGUMENTS) {
             return absl::InvalidArgumentError("not enough arguments for set-path");
         }
 
+        // TODO: remove
+        start++;
+
         // parse path and call setPath
         try {
-            absl::string_view request_path = operation_expression.at(2);
+            absl::string_view request_path = operation_expression.at(2); // TODO: use start
             setPath(request_path);
+
+            if (operation_expression.size() > 3) {
+                auto it = operation_expression.begin() + 3;
+                if (*it != "if") {
+                    return absl::InvalidArgumentError("second argument to set-path must be a condition");
+                }
+
+                const absl::Status status = HeaderProcessor::ConditionProcessorSetup(operation_expression, it+1); // pass everything after the "if"
+
+                if (status != absl::OkStatus()) {
+                    return status;
+                }
+            }
         } catch (const std::exception& e) {
             // should never happen, range is checked above
             return absl::InvalidArgumentError("error parsing request path argument");
         }
 
-        // parse condition expression and call evaluate conditions on the parsed expression
-        const absl::Status status = evaluateCondition();
-        return status;
+        return absl::OkStatus();
     }
 
     void SetPathProcessor::executeOperation(Http::RequestOrResponseHeaderMap& headers) {
+        evaluateCondition();
         const bool condition_result = getCondition(); // whether the condition is true or false
         const std::string request_path = getPath();
 
@@ -94,7 +132,6 @@ namespace HeaderRewriteFilter {
         request_headers->setPath(request_path); // should never return an error
     }
 
-
     void SetBoolProcessor::setStringsToCompare(std::pair<absl::string_view, absl::string_view> strings_to_compare) {
         std::string first_string(strings_to_compare.first);
         std::string second_string(strings_to_compare.second);
@@ -102,13 +139,16 @@ namespace HeaderRewriteFilter {
         strings_to_compare_ = std::make_pair(first_string, second_string); 
     }
 
-    absl::Status SetBoolProcessor::parseOperation(std::vector<absl::string_view>& operation_expression) {
+    absl::Status SetBoolProcessor::parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start) {
         if (operation_expression.size() < Utility::SET_BOOL_MIN_NUM_ARGUMENTS) {
             return absl::InvalidArgumentError("not enough arguments for set-bool");
         }
 
+        // TODO: remove
+        start++;
+
         try {
-            absl::string_view bool_name = operation_expression.at(2);
+            absl::string_view bool_name = operation_expression.at(2); // TODO: use start
             setBoolName(bool_name);
 
             if (operation_expression.at(4) != "-m") {
@@ -158,6 +198,74 @@ namespace HeaderRewriteFilter {
         result_ = result;
     }
 
+    absl::Status ConditionProcessor::parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start) {
+        // TODO: validate start pointer
+        const Utility::BooleanOperatorType start_type = Utility::StringToBooleanOperatorType(*start);
+
+        // conditional can't start with a binary operator
+        if (Utility::isBinaryOperator(start_type)) {
+            return absl::InvalidArgumentError("invalid condition -- condition must begin with '!' or an operand");
+        }
+
+        for (auto it = start; it != operation_expression.end();) {
+            const Utility::BooleanOperatorType operator_type = Utility::StringToBooleanOperatorType(*it);
+
+            // condition can't have two binary operators in a row
+            if (it != start) {
+                const Utility::BooleanOperatorType prev_operator_type = Utility::StringToBooleanOperatorType(*(it-1));
+                if (Utility::isBinaryOperator(operator_type) && Utility::isBinaryOperator(prev_operator_type)) {
+                    return absl::InvalidArgumentError("invalid condition -- cannot have two binary operators in a row");
+                }
+            }
+
+            // condition can't end with an operator
+            if (it+1 == operation_expression.end() && Utility::isOperator(operator_type)) {
+                return absl::InvalidArgumentError("invalid condition -- cannot have an operator at the end of the condition");
+            }
+
+            // parse operation type
+            if (Utility::isBinaryOperator(operator_type)) {
+                operators_.push_back(operator_type);
+                it++;
+            } else if (operator_type == Utility::BooleanOperatorType::Not) {
+                if (it + 1 == operation_expression.end()) {
+                    return absl::InvalidArgumentError("invalid condition -- must have operand after 'not'");
+                } else if (Utility::isOperator(Utility::StringToBooleanOperatorType(*(it+1)))) {
+                    return absl::InvalidArgumentError("invalid condition -- can't have an operator after 'not'");
+                }
+                operands_.push_back(std::pair<absl::string_view, bool>(*(it+1), true));
+                it += 2;
+            } else {
+                operands_.push_back(std::pair<absl::string_view, bool>(*it, false));
+                it++;
+            }
+        }
+
+        // TODO: validate number of operands and operators
+        return absl::OkStatus();
+    }
+
+    bool ConditionProcessor::executeOperation() {
+        if (operands_.size() == 1) {
+            return operands_.at(0).second ? false : true; // TODO: remove mock value
+        }
+
+        bool result = true;
+
+        // evaluate first operation
+        result = Utility::evaluateExpression(operands_.at(0), operators_.at(0), operands_.at(1));
+
+        auto operators_it = operators_.begin() + 1;
+        auto operands_it = operands_.begin() + 2;
+
+        while (operators_it != operators_.end() && operands_it != operands_.end()) {
+            result = Utility::evaluateExpression(result, *operators_it, *operands_it);
+            operators_it++;
+            operands_it++;
+        }
+
+        return result;
+    }
 
 } // namespace HeaderRewriteFilter
 } // namespace HttpFilters

--- a/header-rewrite-filter/header_rewrite.cc
+++ b/header-rewrite-filter/header_rewrite.cc
@@ -77,7 +77,7 @@ HttpHeaderRewriteFilter::HttpHeaderRewriteFilter(HttpHeaderRewriteFilterConfigSh
 
     // parse operation
     if (processor) {
-      const absl::Status status = processor->parseOperation(tokens);
+      const absl::Status status = processor->parseOperation(tokens, tokens.begin());
       if (!status.ok()) {
         fail(status.message());
         setError();

--- a/header-rewrite-filter/utility.cc
+++ b/header-rewrite-filter/utility.cc
@@ -30,6 +30,46 @@ MatchType StringToMatchType(absl::string_view match) {
     }
 }
 
+BooleanOperatorType StringToBooleanOperatorType(absl::string_view bool_operator) {
+    if (bool_operator == "and") {
+        return BooleanOperatorType::And;
+    } else if (bool_operator == "or") {
+        return BooleanOperatorType::Or;
+    } else if (bool_operator == "not") {
+        return BooleanOperatorType::Not;
+    } else {
+        return BooleanOperatorType::None;
+    }
+}
+
+bool isOperator(BooleanOperatorType operator_type) {
+    return (operator_type == BooleanOperatorType::And || operator_type == BooleanOperatorType::Or || operator_type == BooleanOperatorType::Not);
+}
+
+bool isBinaryOperator(BooleanOperatorType operator_type) {
+    return (operator_type == BooleanOperatorType::And || operator_type == BooleanOperatorType::Or);
+}
+
+bool evaluateExpression(std::pair<absl::string_view, bool> operand1, BooleanOperatorType operator_val, std::pair<absl::string_view, bool> operand2) {
+    // TODO: remove mock values
+    
+    bool op1 = operand1.second ? false : true;
+    bool op2 = operand2.second ? false : true;
+
+    if (operator_val == BooleanOperatorType::And) return op1 && op2;
+    return op1 || op2;
+}
+
+bool evaluateExpression(bool operand1, BooleanOperatorType operator_val, std::pair<absl::string_view, bool> operand2) {
+    // TODO: remove mock values
+
+    bool op2 = operand2.second ? false : true;
+
+    if (operator_val == BooleanOperatorType::And) return operand1 && op2;
+    return operand1 || op2;
+}
+
+
 } // namespace Utility
 } // namespace HeaderRewriteFilter
 } // namespace HttpFilters

--- a/header-rewrite-filter/utility.h
+++ b/header-rewrite-filter/utility.h
@@ -35,8 +35,21 @@ enum class MatchType : int {
   InvalidMatchType,
 };
 
+enum class BooleanOperatorType : int {
+  And,
+  Or,
+  Not,
+  None,
+};
+
 OperationType StringToOperationType(absl::string_view operation);
 MatchType StringToMatchType(absl::string_view match);
+BooleanOperatorType StringToBooleanOperatorType(absl::string_view bool_operator);
+
+bool isOperator(BooleanOperatorType operator_type);
+bool isBinaryOperator(BooleanOperatorType operator_type);
+bool evaluateExpression(std::pair<absl::string_view, bool> operand1, BooleanOperatorType operator_val, std::pair<absl::string_view, bool> operand2);
+bool evaluateExpression(bool operand1, BooleanOperatorType operator_val, std::pair<absl::string_view, bool> operand2);
 
 } // namespace Utility
 } // namespace HeaderRewriteFilter


### PR DESCRIPTION
### Description

This PR extends the set-header and set-path operations to execute their respective operation based on a condition.

An example config looks like this:
```
http set-bool mock_bool matches -m str matches // this currently isn't hooked up to the ConditionProcessor
http-request set-path mockpath if not A
http-request set-header mock_header mock_value if A and B and C
http-response set-header mock_key mock_val1 mock_val2 if not A
```

Note: the conditionals are implemented with mock values where A, B, and C are always true.

See [this doc](https://datadoghq.atlassian.net/wiki/spaces/~712020ba1b13e5868d45e49dbc041828ac0041/blog/2023/06/30/3077636109/Building+Running+an+Envoy+Filter+Plugin) for documentation on building and running the envoy filter plugin.

### Testing
```
// Write a config for the filter
// Eg. "http-request set-path mockpath if not A
http-request set-header mock_header mock_value if A and B and C
http-response set-header mock_key mock_val1 mock_val2 if not A"

// Build and run envoy
bazel build //http-filter-example:envoy
./bazel-bin/http-filter-example/envoy -c ./http-filter-example/envoy-sample-config.yaml

// Set up Docker backend to echo http headers and send a curl request to envoy
// Docker image found here: https://hub.docker.com/r/ealen/echo-server
curl localhost:8081
```

Request looks like this:
```
GET / HTTP/1.1
host: localhost:8081
user-agent: curl/7.68.0
accept: */*
x-forwarded-proto: http
mock_header: mock_value
x-request-id: da84ddbf-ddcd-43a6-aa1a-54ad50a97286
x-envoy-expected-rq-timeout-ms: 15000
```

Response looks like this:
```
$ curl -v localhost:8081
*   Trying 127.0.0.1:8081...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8081 (#0)
> GET / HTTP/1.1
> Host: localhost:8081
> User-Agent: curl/7.68.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< x-envoy-upstream-service-time: 0
< date: Tue, 18 Jul 2023 19:13:23 GMT
< server: envoy
< transfer-encoding: chunked
```
In this example, the `mock_header` request header  has been set to `mock_value` because `A and B and C` evaluates to true. The first and third operations are not executed because `not A` evaluates to false.

Let's try this config:
```
http-request set-path mockpath if not A
http-request set-header mock_header mock_value if A and B and C
http-response set-header mock_key mock_val1 mock_val2
```

The request looks like this:
```
GET mockpath HTTP/1.1
host: localhost:8081
user-agent: curl/7.68.0
accept: */*
x-forwarded-proto: http
x-request-id: e3267434-c84a-43d8-8cfe-b6241b071cf2
x-envoy-expected-rq-timeout-ms: 15000
```

The response looks like this:
```
$ curl -v localhost:8081
*   Trying 127.0.0.1:8081...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8081 (#0)
> GET / HTTP/1.1
> Host: localhost:8081
> User-Agent: curl/7.68.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< x-envoy-upstream-service-time: 0
< mock_key: mock_val1
< mock_key: mock_val2
< date: Tue, 18 Jul 2023 19:30:37 GMT
< server: envoy
< transfer-encoding: chunked
```
In this example, the first and third operations have been executed because their respective conditions are true (note that there is no explicit condition in the third operation). The second operation is not executed because the condition is false.