### PR TITLE
Incorporate SetBoolProcessor into ConditionProcessor

### DIFF
--- a/header-rewrite-filter/envoy-sample-config.yaml
+++ b/header-rewrite-filter/envoy-sample-config.yaml
@@ -47,9 +47,10 @@ static_resources:
               key: header-processing
               val: |
                   http set-bool mock_bool matches -m str matches
-                  http-request set-path mockpath if not A
-                  http-request set-header x-forwarded-proto https if A and B and C
-                  http-response set-header mock_key mock_val1 mock_val2 if not A
+                  http set-bool another_mock_bool no-match -m str matches
+                  http-request set-path mockpath if not another_mock_bool
+                  http-request set-header x-forwarded-proto https if mock_bool and mock_bool or not mock_bool
+                  http-response set-header mock_key mock_val1 mock_val2 if another_mock_bool or not another_mock_bool and mock_bool
           - name: envoy.filters.http.router
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/header-rewrite-filter/header_processor.cc
+++ b/header-rewrite-filter/header_processor.cc
@@ -7,6 +7,15 @@ namespace Extensions {
 namespace HttpFilters {
 namespace HeaderRewriteFilter {
 
+    absl::Status HeaderProcessor::ConditionProcessorSetup(std::vector<absl::string_view>& condition_expression, std::vector<absl::string_view>::iterator start) {
+        if (start == condition_expression.end()) {
+            return absl::InvalidArgumentError("empty condition provided");
+        }
+
+        setConditionProcessor(std::make_shared<ConditionProcessor>());
+        return getConditionProcessor()->parseOperation(condition_expression, start); // pass everything after the "if"
+    }
+
     absl::Status SetHeaderProcessor::parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start) {
         if (operation_expression.size() < Utility::SET_HEADER_MIN_NUM_ARGUMENTS) {
             return absl::InvalidArgumentError("not enough arguments for set-header");
@@ -47,40 +56,41 @@ namespace HeaderRewriteFilter {
         return absl::OkStatus();
     }
 
-    absl::Status HeaderProcessor::evaluateCondition() {
+    absl::Status HeaderProcessor::evaluateCondition(SetBoolProcessorMapSharedPtr bool_processors) {
         // call ConditionProcessor executeOperation; if it is null, return true
         bool result = true;
-        if (getConditionProcessor()) {
-            result = getConditionProcessor()->executeOperation();
+        ConditionProcessorSharedPtr condition_processor = getConditionProcessor();
+        if (condition_processor) {
+            const absl::Status status = condition_processor->executeOperation(bool_processors);
+            if (status != absl::OkStatus()) {
+                return status;
+            }
+            result = condition_processor->getConditionResult();
         }
         setCondition(result);
 
         return absl::OkStatus();
     }
 
-    absl::Status HeaderProcessor::ConditionProcessorSetup(std::vector<absl::string_view>& condition_expression, std::vector<absl::string_view>::iterator start) {
-        if (start == condition_expression.end()) {
-            return absl::InvalidArgumentError("empty condition provided");
+    absl::Status SetHeaderProcessor::executeOperation(Http::RequestOrResponseHeaderMap& headers, SetBoolProcessorMapSharedPtr bool_processors) {
+        const absl::Status status = evaluateCondition(bool_processors);
+        if (status != absl::OkStatus()) {
+            return status;
         }
-
-        setConditionProcessor(std::make_shared<ConditionProcessor>());
-        return getConditionProcessor()->parseOperation(condition_expression, start); // pass everything after the "if"
-    }
-
-    void SetHeaderProcessor::executeOperation(Http::RequestOrResponseHeaderMap& headers) {
-        evaluateCondition();
-        bool condition_result = getCondition(); // whether the condition is true or false
+        const bool condition_result = getCondition(); // whether the condition is true or false
         const std::string key = getKey();
         const std::vector<std::string>& header_vals = getVals();
 
         if (!condition_result) {
-            return; // do nothing because condition is false
+            return absl::OkStatus(); // do nothing because condition is false
         }
         
         // set header
         for (auto const& header_val : header_vals) {
             headers.appendCopy(Http::LowerCaseString(key), header_val); // should never return an error
         }
+
+        return absl::OkStatus();
     }
 
     absl::Status SetPathProcessor::parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start) {
@@ -116,13 +126,17 @@ namespace HeaderRewriteFilter {
         return absl::OkStatus();
     }
 
-    void SetPathProcessor::executeOperation(Http::RequestOrResponseHeaderMap& headers) {
-        evaluateCondition();
+    absl::Status SetPathProcessor::executeOperation(Http::RequestOrResponseHeaderMap& headers, SetBoolProcessorMapSharedPtr bool_processors) {
+        const absl::Status status = evaluateCondition(bool_processors);
+        if (status != absl::OkStatus()) {
+            return status;
+        }
+
         const bool condition_result = getCondition(); // whether the condition is true or false
         const std::string request_path = getPath();
 
         if (!condition_result) {
-            return; // do nothing because condition is false
+            return absl::OkStatus(); // do nothing because condition is false
         }
 
         // cast to RequestHeaderMap because setPath is only on request side
@@ -130,6 +144,8 @@ namespace HeaderRewriteFilter {
         
         // set path (path being set here includes the query string)
         request_headers->setPath(request_path); // should never return an error
+
+        return absl::OkStatus();
     }
 
     void SetBoolProcessor::setStringsToCompare(std::pair<absl::string_view, absl::string_view> strings_to_compare) {
@@ -180,7 +196,7 @@ namespace HeaderRewriteFilter {
         return absl::OkStatus();
     }
 
-    void SetBoolProcessor::executeOperation(Http::RequestOrResponseHeaderMap& headers) {
+    absl::Status SetBoolProcessor::executeOperation() {
         const Utility::MatchType match_type = getMatchType();
 
         bool result;
@@ -189,12 +205,16 @@ namespace HeaderRewriteFilter {
             case Utility::MatchType::Exact:
                 result = (getStringsToCompare().first == getStringsToCompare().second);
                 break;
+            case Utility::MatchType::Substr:
+                break;
             // TODO: implement rest of the match cases
             default:
                 result = false;
         }
 
         result_ = result;
+
+        return absl::OkStatus();
     }
 
     absl::Status ConditionProcessor::parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start) {
@@ -240,30 +260,54 @@ namespace HeaderRewriteFilter {
             }
         }
 
-        // TODO: validate number of operands and operators
-        return absl::OkStatus();
+        // validate number of operands and operators
+        return (operators_.size() == operands_.size() - 1) ? absl::OkStatus() : absl::InvalidArgumentError("invalid condition");
     }
 
-    bool ConditionProcessor::executeOperation() {
-        if (operands_.size() == 1) {
-            return operands_.at(0).second ? false : true; // TODO: remove mock value
+    absl::Status ConditionProcessor::executeOperation(SetBoolProcessorMapSharedPtr set_bool_processors) {
+        try {
+            absl::Status status;
+            bool bool_var;
+            SetBoolProcessorSharedPtr bool_processor = set_bool_processors->at(std::string(operands_.at(0).first));
+            if (operands_.size() >= 1) { // this function should never be called if there are no operands
+                // look up the bool in the map, evaluate the value of the bool, and store the result
+                status = bool_processor->executeOperation();
+                if (status != absl::OkStatus()) {
+                    return status;
+                }
+                bool_var = bool_processor->getResult(operands_.at(0).second);
+                if (operands_.size() == 1) {
+                    condition_ = bool_var;
+                    return absl::OkStatus();
+                }
+            }
+
+            bool result = bool_var;
+
+            auto operators_it = operators_.begin();
+            auto operands_it = operands_.begin() + 1;
+
+            // continue evaluating the condition from left to right
+            while (operators_it != operators_.end() && operands_it != operands_.end()) {
+                bool_processor = set_bool_processors->at(std::string((*operands_it).first));
+                status = bool_processor->executeOperation();
+                if (status != absl::OkStatus()) {
+                    return status;
+                }
+                bool_var = bool_processor->getResult((*operands_it).second);
+                result = Utility::evaluateExpression(result, *operators_it, bool_var);
+                operators_it++;
+                operands_it++;
+            }
+            
+            // store the result
+            condition_ = result;
+
+            return absl::OkStatus();
+
+        } catch (std::exception& e) { // fails gracefully if a faulty map access occurs
+            return absl::InvalidArgumentError("failed to process condition");
         }
-
-        bool result = true;
-
-        // evaluate first operation
-        result = Utility::evaluateExpression(operands_.at(0), operators_.at(0), operands_.at(1));
-
-        auto operators_it = operators_.begin() + 1;
-        auto operands_it = operands_.begin() + 2;
-
-        while (operators_it != operators_.end() && operands_it != operands_.end()) {
-            result = Utility::evaluateExpression(result, *operators_it, *operands_it);
-            operators_it++;
-            operands_it++;
-        }
-
-        return result;
     }
 
 } // namespace HeaderRewriteFilter

--- a/header-rewrite-filter/header_processor.h
+++ b/header-rewrite-filter/header_processor.h
@@ -14,29 +14,62 @@ namespace HeaderRewriteFilter {
 
 class Processor {
 public:
+  Processor() {}
   virtual ~Processor() {}
   virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start) { return absl::OkStatus(); }
-  virtual void executeOperation(Http::RequestOrResponseHeaderMap& headers) { }
 };
+
+class SetBoolProcessor : public Processor {
+public:
+  SetBoolProcessor() {}
+  virtual ~SetBoolProcessor() {}
+  virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start);
+  virtual absl::Status executeOperation();
+  const std::string& getBoolName() const { return bool_name_; }
+  const bool getResult(bool negate) const { return negate ? !result_ : result_; }
+
+private:
+  void setBoolName(absl::string_view bool_name) { bool_name_ = std::string(bool_name); }
+
+  const std::pair<std::string, std::string>& getStringsToCompare() const { return strings_to_compare_; }
+  void setStringsToCompare(std::pair<absl::string_view, absl::string_view> strings_to_compare);
+
+  Utility::MatchType getMatchType() const { return match_type_; }
+  void setMatchType(Utility::MatchType match_type) { match_type_ = match_type; }
+
+  std::string bool_name_;
+  std::pair<std::string, std::string> strings_to_compare_;
+  Utility::MatchType match_type_;
+  bool result_;
+};
+
+
+using SetBoolProcessorSharedPtr = std::shared_ptr<SetBoolProcessor>;
+using SetBoolProcessorMapSharedPtr = std::shared_ptr<std::unordered_map<std::string, SetBoolProcessorSharedPtr>>;
 
 class ConditionProcessor : public Processor {
 public:
+  ConditionProcessor() {}
   virtual ~ConditionProcessor() {}
   virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start);
-  bool executeOperation();
+  virtual absl::Status executeOperation(SetBoolProcessorMapSharedPtr bool_processors);
+
+  bool getConditionResult() const { return condition_; }
 
 private:
   std::vector<Utility::BooleanOperatorType> operators_;
   std::vector<std::pair<absl::string_view, bool>> operands_; // operand and whether that operand is negated
-  bool isTrue_; // Note: will be used when connecting ConditionProcessor to SetBoolProcessor
+  bool condition_;
 };
 
 using ConditionProcessorSharedPtr = std::shared_ptr<ConditionProcessor>;
 
 class HeaderProcessor : public Processor {
 public:
+  HeaderProcessor() {}
   virtual ~HeaderProcessor() {}
-  virtual absl::Status evaluateCondition();
+  virtual absl::Status executeOperation(Http::RequestOrResponseHeaderMap& headers, SetBoolProcessorMapSharedPtr bool_processors) { return absl::OkStatus(); }
+  virtual absl::Status evaluateCondition(SetBoolProcessorMapSharedPtr bool_processors);
   bool getCondition() const { return condition_; }
   void setCondition(bool result) { condition_ = result; }
   void setConditionProcessor(ConditionProcessorSharedPtr condition_processor) { condition_processor_ = condition_processor; }
@@ -55,8 +88,7 @@ public:
   SetHeaderProcessor() {}
   virtual ~SetHeaderProcessor() {}
   virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start);
-  virtual void executeOperation(Http::RequestOrResponseHeaderMap& headers);
-
+  virtual absl::Status executeOperation(Http::RequestOrResponseHeaderMap& headers, SetBoolProcessorMapSharedPtr bool_processors);
 private:
   // Note: the values returned by these functions must not outlive the SetHeaderProcessor object
   const std::string& getKey() const { return header_key_; }
@@ -75,36 +107,13 @@ public:
   SetPathProcessor() {}
   virtual ~SetPathProcessor() {}
   virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start);
-  virtual void executeOperation(Http::RequestOrResponseHeaderMap& headers);
+  virtual absl::Status executeOperation(Http::RequestOrResponseHeaderMap& headers, SetBoolProcessorMapSharedPtr bool_processors);
 
 private:
   const std::string& getPath() const { return request_path_; }
   void setPath(absl::string_view path) { request_path_ = std::string(path); }
 
   std::string request_path_; // path to set
-};
-
-class SetBoolProcessor : public Processor {
-public:
-  virtual ~SetBoolProcessor() {}
-  virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start);
-  virtual void executeOperation(Http::RequestOrResponseHeaderMap& headers);
-  const std::string& getBoolName() const { return bool_name_; }
-  const bool getResult() const { return result_; }
-
-private:
-  void setBoolName(absl::string_view bool_name) { bool_name_ = std::string(bool_name); }
-
-  const std::pair<std::string, std::string>& getStringsToCompare() const { return strings_to_compare_; }
-  void setStringsToCompare(std::pair<absl::string_view, absl::string_view> strings_to_compare);
-
-  Utility::MatchType getMatchType() const { return match_type_; }
-  void setMatchType(Utility::MatchType match_type) { match_type_ = match_type; }
-
-  std::string bool_name_;
-  std::pair<std::string, std::string> strings_to_compare_;
-  Utility::MatchType match_type_;
-  bool result_;
 };
 
 } // namespace HeaderRewriteFilter

--- a/header-rewrite-filter/header_rewrite.h
+++ b/header-rewrite-filter/header_rewrite.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <string>
-#include <unordered_set>
 
 #include "header_processor.h"
 
@@ -27,9 +26,9 @@ private:
 };
 
 using HttpHeaderRewriteFilterConfigSharedPtr = std::shared_ptr<HttpHeaderRewriteFilterConfig>;
-using ProcessorUniquePtr = std::unique_ptr<Processor>;
 using HeaderProcessorUniquePtr = std::unique_ptr<HeaderProcessor>;
-using SetBoolProcessorUniquePtr = std::unique_ptr<SetBoolProcessor>;
+using SetBoolProcessorSharedPtr = std::shared_ptr<SetBoolProcessor>;
+using SetBoolProcessorMapSharedPtr = std::shared_ptr<std::unordered_map<std::string, SetBoolProcessorSharedPtr>>;
 
 class HttpHeaderRewriteFilter : public Http::PassThroughFilter {
 public:
@@ -48,23 +47,17 @@ private:
   bool error_ = false;
 
   // header processors
-  std::vector<ProcessorUniquePtr> request_header_processors_;
-  std::vector<ProcessorUniquePtr> response_header_processors_;
+  std::vector<HeaderProcessorUniquePtr> request_header_processors_;
+  std::vector<HeaderProcessorUniquePtr> response_header_processors_;
 
   // set_bool processors
-  std::unordered_map<std::string, ProcessorUniquePtr> set_bool_processors_;
+  SetBoolProcessorMapSharedPtr set_bool_processors_;
 
   const Http::LowerCaseString headerKey() const;
   const std::string headerValue() const;
   void setError() { error_ = true; }
   bool getError() const { return error_; };
 };
-
-// TODO: might need to throw an exception in the future
-// class FilterException : public EnvoyException {
-// public:
-//   using EnvoyException::EnvoyException;
-// };
 
 } // namespace HeaderRewriteFilter
 } // namespace HttpFilters

--- a/header-rewrite-filter/utility.cc
+++ b/header-rewrite-filter/utility.cc
@@ -50,23 +50,9 @@ bool isBinaryOperator(BooleanOperatorType operator_type) {
     return (operator_type == BooleanOperatorType::And || operator_type == BooleanOperatorType::Or);
 }
 
-bool evaluateExpression(std::pair<absl::string_view, bool> operand1, BooleanOperatorType operator_val, std::pair<absl::string_view, bool> operand2) {
-    // TODO: remove mock values
-    
-    bool op1 = operand1.second ? false : true;
-    bool op2 = operand2.second ? false : true;
-
-    if (operator_val == BooleanOperatorType::And) return op1 && op2;
-    return op1 || op2;
-}
-
-bool evaluateExpression(bool operand1, BooleanOperatorType operator_val, std::pair<absl::string_view, bool> operand2) {
-    // TODO: remove mock values
-
-    bool op2 = operand2.second ? false : true;
-
-    if (operator_val == BooleanOperatorType::And) return operand1 && op2;
-    return operand1 || op2;
+bool evaluateExpression(bool operand1, BooleanOperatorType operator_val, bool operand2) {
+    if (operator_val == BooleanOperatorType::And) return operand1 && operand2;
+    return operand1 || operand2;
 }
 
 

--- a/header-rewrite-filter/utility.h
+++ b/header-rewrite-filter/utility.h
@@ -48,8 +48,7 @@ BooleanOperatorType StringToBooleanOperatorType(absl::string_view bool_operator)
 
 bool isOperator(BooleanOperatorType operator_type);
 bool isBinaryOperator(BooleanOperatorType operator_type);
-bool evaluateExpression(std::pair<absl::string_view, bool> operand1, BooleanOperatorType operator_val, std::pair<absl::string_view, bool> operand2);
-bool evaluateExpression(bool operand1, BooleanOperatorType operator_val, std::pair<absl::string_view, bool> operand2);
+bool evaluateExpression(bool operand1, BooleanOperatorType operator_val, bool operand2);
 
 } // namespace Utility
 } // namespace HeaderRewriteFilter


### PR DESCRIPTION
### Description

This PR completes the implementation of conditional logic in the header rewrite filter. It allows `set-header` and `set-path` to be implemented based on a condition. A condition consists of a sequence of boolean variables joined by and/or. Each variable can also be negated.

An example config looks like this:
```
http set-bool mock_true_bool mock_string -m str mock_string
http set-bool mock_false_bool no-match -m str mock_string
http-request set-path mockpath if not mock_false_bool
http-request set-header mock_header mock_value if mock_true_bool and mock_true_bool or not mock_true_bool
http-response set-header mock_key mock_val1 mock_val2 if mock_false_bool or not mock_false_bool and mock_true_bool
```

See [this doc](https://datadoghq.atlassian.net/wiki/spaces/~712020ba1b13e5868d45e49dbc041828ac0041/blog/2023/06/30/3077636109/Building+Running+an+Envoy+Filter+Plugin) for documentation on building and running the envoy filter plugin.

### Testing
```
// Write a config for the filter
// Eg. http set-bool mock_true_bool mock_string -m str mock_string
http set-bool mock_false_bool no-match -m str mock_string
http-request set-path mockpath if not mock_false_bool
http-request set-header mock_header mock_value if mock_true_bool and mock_true_bool or not mock_true_bool
http-response set-header mock_key mock_val1 mock_val2 if mock_false_bool or not mock_false_bool and mock_true_bool

// Build and run envoy
bazel build //http-filter-example:envoy
./bazel-bin/http-filter-example/envoy -c ./http-filter-example/envoy-sample-config.yaml

// Set up Docker backend to echo http headers and send a curl request to envoy
// Docker image found here: https://hub.docker.com/r/ealen/echo-server
curl localhost:8081
```

Example config:
```
http set-bool mock_true_bool matches -m str matches
http set-bool mock_false_bool no-match -m str matches
http-request set-path mockpath if not mock_false_bool
http-request set-header x-forwarded-proto https if mock_true_bool and mock_true_bool or not mock_true_bool
http-response set-header mock_key mock_val1 mock_val2 if mock_false_bool or not mock_false_bool and mock_true_bool
```

Request-side:
```
GET mockpath HTTP/1.1
host: localhost:8081
user-agent: curl/7.68.0
accept: */*
x-forwarded-proto: http,https
x-request-id: 0f3165c4-1222-453b-ba6b-f59047f5cb80
x-envoy-expected-rq-timeout-ms: 15000
```

Response side:
```
$ curl -v localhost:8081
*   Trying 127.0.0.1:8081...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8081 (#0)
> GET / HTTP/1.1
> Host: localhost:8081
> User-Agent: curl/7.68.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< x-envoy-upstream-service-time: 0
< mock_key: mock_val1
< mock_key: mock_val2
< date: Tue, 18 Jul 2023 21:21:35 GMT
< server: envoy
< transfer-encoding: chunked
```
All operations are executed because all conditions are true.

Another example config:
```
http set-bool mock_true_bool matches -m str matches
http set-bool mock_false_bool no-match -m str matches
http-request set-path mockpath if mock_false_bool
http-request set-header x-forwarded-proto https if mock_true_bool and not mock_true_bool or not mock_true_bool
http-response set-header mock_key mock_val1 mock_val2 if mock_false_bool or mock_false_bool and mock_true_bool
```
Request side:
```
GET / HTTP/1.1
host: localhost:8081
user-agent: curl/7.68.0
accept: */*
x-forwarded-proto: http
x-request-id: 9194da7d-49d9-497d-8abf-dae533d81c88
x-envoy-expected-rq-timeout-ms: 15000
```

Response side:
```
$ curl -v localhost:8081
*   Trying 127.0.0.1:8081...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8081 (#0)
> GET / HTTP/1.1
> Host: localhost:8081
> User-Agent: curl/7.68.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< x-envoy-upstream-service-time: 0
< date: Tue, 18 Jul 2023 21:23:37 GMT
< server: envoy
< transfer-encoding: chunked
```
No operations are executed because none of the conditions are true.