### PR TITLE
added unit tests for set-header, set-path processors

### DIFF
--- a/header-rewrite-filter/BUILD
+++ b/header-rewrite-filter/BUILD
@@ -75,3 +75,13 @@ envoy_cc_test(
         "@envoy//test/integration:http_integration_lib",
     ],
 )
+
+envoy_cc_test(
+    name = "header_processor_test",
+    srcs = ["header_processor_test.cc"],
+    repository = "@envoy",
+    deps = [
+        ":header_rewrite_processor_lib",
+         "@envoy//test/integration:http_integration_lib",
+    ]
+)

--- a/header-rewrite-filter/header_processor.cc
+++ b/header-rewrite-filter/header_processor.cc
@@ -134,8 +134,7 @@ namespace HeaderRewriteFilter {
             }
 
         } catch (const std::exception& e) {
-            // should never happen, range is checked above
-            return absl::InvalidArgumentError("error parsing request path argument");
+            return absl::InvalidArgumentError("error parsing boolean expression");
         }
 
         return absl::OkStatus();

--- a/header-rewrite-filter/header_processor_test.cc
+++ b/header-rewrite-filter/header_processor_test.cc
@@ -1,0 +1,101 @@
+#include "gtest/gtest.h"
+#include "header_processor.h"
+#include "source/common/common/utility.h"
+#include "source/extensions/filters/http/common/pass_through_filter.h"
+#include "test/integration/http_integration.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace HeaderRewriteFilter {
+
+class ProcessorTest : public ::testing::Test {
+protected:
+    void SetUp() override { }
+};
+
+// Note: both processors assume that the first two arguments are validated (these arguments are validated by the filter)
+
+TEST_F(ProcessorTest, SetHeaderProcessorTest) {
+    SetHeaderProcessor set_header_processor = SetHeaderProcessor();
+    Http::TestRequestHeaderMapImpl headers{
+        {":method", "GET"}, {":path", "/"}, {":authority", "host"}};
+
+    // TODO: will be changed once append-header operation is added
+    // can set one value
+    std::vector<absl::string_view> operation_expression({"http-request", "set-header", "mock_header", "mock_value"});
+    absl::Status status = set_header_processor.parseOperation(operation_expression);
+    EXPECT_TRUE(status == absl::OkStatus());
+    set_header_processor.executeOperation(headers);
+    EXPECT_EQ("mock_value", headers.get(Http::LowerCaseString("mock_header"))[0]->value().getStringView());
+
+    // can set multiple values
+    operation_expression = {"http-response", "set-header", "mock_key", "mock_val1", "mock_val2"};
+    status = set_header_processor.parseOperation(operation_expression);
+    EXPECT_TRUE(status == absl::OkStatus());
+    set_header_processor.executeOperation(headers);
+    EXPECT_EQ("mock_val1", headers.get(Http::LowerCaseString("mock_key"))[0]->value().getStringView());
+    EXPECT_EQ("mock_val2", headers.get(Http::LowerCaseString("mock_key"))[1]->value().getStringView());
+
+    // missing argument
+    operation_expression = {"http-response", "set-header", "mock_key"};
+    status = set_header_processor.parseOperation(operation_expression);
+    EXPECT_TRUE(status != absl::OkStatus());
+    EXPECT_EQ(status.message(), "not enough arguments for set-header");
+
+}
+
+TEST_F(ProcessorTest, SetPathProcessorTest) {
+    SetPathProcessor set_path_processor = SetPathProcessor();
+    Http::TestRequestHeaderMapImpl headers{
+        {":method", "GET"}, {":path", "/"}, {":authority", "host"}};
+
+    std::vector<absl::string_view> operation_expression({"http-request", "set-path", "mock_path"});
+    absl::Status status = set_path_processor.parseOperation(operation_expression);
+    EXPECT_TRUE(status == absl::OkStatus());
+    set_path_processor.executeOperation(headers);
+    EXPECT_EQ("mock_path", headers.get(Http::LowerCaseString(":path"))[0]->value().getStringView());
+
+    // missing argument
+    operation_expression = {"http-request", "set-path"};
+    status = set_path_processor.parseOperation(operation_expression);
+    EXPECT_TRUE(status != absl::OkStatus());
+    EXPECT_EQ(status.message(), "not enough arguments for set-path");
+}
+
+TEST_F(ProcessorTest, SetBoolProcessorTest) {
+    SetBoolProcessor set_bool_processor = SetBoolProcessor();
+
+    Http::TestRequestHeaderMapImpl headers{
+        {":method", "GET"}, {":path", "/"}, {":authority", "host"}};
+    
+    // positive exact match
+    std::vector<absl::string_view> operation_expression({"http", "set-bool", "mock_bool", "matches", "-m", "str", "matches"});
+    absl::Status status = set_bool_processor.parseOperation(operation_expression);
+    EXPECT_TRUE(status == absl::OkStatus());
+    set_bool_processor.executeOperation(headers);
+    EXPECT_TRUE(set_bool_processor.getResult());
+
+    // negative exact match
+    operation_expression = {"http", "set-bool", "mock_bool", "no-match", "-m", "str", "match"};
+    status = set_bool_processor.parseOperation(operation_expression);
+    EXPECT_TRUE(status == absl::OkStatus());
+    set_bool_processor.executeOperation(headers);
+    EXPECT_FALSE(set_bool_processor.getResult());
+
+    // invalid number of arguments
+    operation_expression = {"http", "set-bool", "mock_bool", "matches", "-m", "str"};
+    status = set_bool_processor.parseOperation(operation_expression);
+    EXPECT_EQ(status.message(), "error parsing boolean expression");
+
+    // missing -m flag
+    operation_expression = {"http", "set-bool", "mock_bool", "matches", "str", "matches"};
+    status = set_bool_processor.parseOperation(operation_expression);
+    EXPECT_EQ(status.message(), "invalid match syntax");
+    EXPECT_FALSE(set_bool_processor.getResult());
+}
+
+} // namespace HeaderRewriteFilter
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy


### PR DESCRIPTION
Added basic unit tests for `SetHeaderProcessor` and `SetPathProcessor`. This branch is based off main, which is why it does not cover boolean variables, conditions, and the interactions between the classes. I will go back and add more tests once the current stack of PRs is merged.

Test result:
```
$ bazel test //header-rewrite-filter:header_processor_test
INFO: Analyzed target //header-rewrite-filter:header_processor_test (0 packages loaded, 0 targets configured).
INFO: Found 1 test target...
Target //header-rewrite-filter:header_processor_test up-to-date:
  bazel-bin/header-rewrite-filter/header_processor_test
INFO: Elapsed time: 17.142s, Critical Path: 16.75s
INFO: 4 processes: 1 internal, 3 linux-sandbox.
INFO: Build completed successfully, 4 total actions

Executed 1 out of 1 test: 1 test passes.
```