### PR TITLE
modified set path implementation

### DIFF
--- a/header-rewrite-filter/BUILD
+++ b/header-rewrite-filter/BUILD
@@ -52,6 +52,7 @@ envoy_cc_library(
     deps = [
         ":pkg_cc_proto",
         ":header_rewrite_utils_lib",
+        "@envoy//source/common/common:minimal_logger_lib",
         "@envoy//source/extensions/filters/http/common:pass_through_filter_lib",
     ],
 )

--- a/header-rewrite-filter/envoy-sample-config.yaml
+++ b/header-rewrite-filter/envoy-sample-config.yaml
@@ -48,7 +48,7 @@ static_resources:
               val: |
                   http set-bool mock_bool matches -m str matches
                   http-request set-path mockpath
-                  http-request set-header x-forwarded-proto https
+                  http-request set-header x-forwarded-proto https if A and B and not C
                   http-response set-header mock_key mock_val1 mock_val2
           - name: envoy.filters.http.router
             typed_config:

--- a/header-rewrite-filter/envoy-sample-config.yaml
+++ b/header-rewrite-filter/envoy-sample-config.yaml
@@ -47,9 +47,10 @@ static_resources:
               key: header-processing
               val: |
                   http set-bool mock_bool matches -m str matches
-                  http-request set-path mockpath if not A
-                  http-request set-header x-forwarded-proto https if A and B and C
-                  http-response set-header mock_key mock_val1 mock_val2 if not A
+                  http set-bool another_mock_bool no-match -m str matches
+                  http-request set-path mockpath if mock_bool
+                  http-request set-header x-forwarded-proto https if another_mock_bool
+                  http-request set-header mock_key mock_val1 mock_val2 if mock_bool
           - name: envoy.filters.http.router
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/header-rewrite-filter/envoy-sample-config.yaml
+++ b/header-rewrite-filter/envoy-sample-config.yaml
@@ -48,9 +48,9 @@ static_resources:
               val: |
                   http set-bool mock_bool matches -m str matches
                   http set-bool another_mock_bool no-match -m str matches
-                  http-request set-path mockpath if mock_bool
-                  http-request set-header x-forwarded-proto https if another_mock_bool
-                  http-request set-header mock_key mock_val1 mock_val2 if mock_bool
+                  http-request set-path mockpath if not another_mock_bool
+                  http-request set-header x-forwarded-proto https if mock_bool and mock_bool or not mock_bool
+                  http-request set-header mock_key mock_val1 mock_val2 if another_mock_bool or not another_mock_bool and mock_bool
           - name: envoy.filters.http.router
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/header-rewrite-filter/envoy-sample-config.yaml
+++ b/header-rewrite-filter/envoy-sample-config.yaml
@@ -46,6 +46,7 @@ static_resources:
               "@type": type.googleapis.com/envoy.extensions.filters.http.HeaderRewrite
               key: header-processing
               val: |
+                  http set-bool mock_bool matches -m str "matches"
                   http-request set-path mockpath
                   http-request set-header x-forwarded-proto https
                   http-response set-header mock_key mock_val1 mock_val2
@@ -71,4 +72,4 @@ static_resources:
             address:
               socket_address:
                 address: 127.0.0.1
-                port_value: 3000 # connected to dummy docker backend
+                port_value: 8000 # connected to dummy docker backend

--- a/header-rewrite-filter/envoy-sample-config.yaml
+++ b/header-rewrite-filter/envoy-sample-config.yaml
@@ -47,9 +47,9 @@ static_resources:
               key: header-processing
               val: |
                   http set-bool mock_bool matches -m str matches
-                  http-request set-path mockpath
-                  http-request set-header x-forwarded-proto https if A and B and not C
-                  http-response set-header mock_key mock_val1 mock_val2
+                  http-request set-path mockpath if not A
+                  http-request set-header x-forwarded-proto https if A and B and C
+                  http-response set-header mock_key mock_val1 mock_val2 if not A
           - name: envoy.filters.http.router
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/header-rewrite-filter/envoy-sample-config.yaml
+++ b/header-rewrite-filter/envoy-sample-config.yaml
@@ -46,7 +46,7 @@ static_resources:
               "@type": type.googleapis.com/envoy.extensions.filters.http.HeaderRewrite
               key: header-processing
               val: |
-                  http set-bool mock_bool matches -m str "matches"
+                  http set-bool mock_bool matches -m str matches
                   http-request set-path mockpath
                   http-request set-header x-forwarded-proto https
                   http-response set-header mock_key mock_val1 mock_val2

--- a/header-rewrite-filter/envoy-sample-config.yaml
+++ b/header-rewrite-filter/envoy-sample-config.yaml
@@ -50,7 +50,7 @@ static_resources:
                   http set-bool another_mock_bool no-match -m str matches
                   http-request set-path mockpath if not another_mock_bool
                   http-request set-header x-forwarded-proto https if mock_bool and mock_bool or not mock_bool
-                  http-request set-header mock_key mock_val1 mock_val2 if another_mock_bool or not another_mock_bool and mock_bool
+                  http-response set-header mock_key mock_val1 mock_val2 if another_mock_bool or not another_mock_bool and mock_bool
           - name: envoy.filters.http.router
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/header-rewrite-filter/header_processor.cc
+++ b/header-rewrite-filter/header_processor.cc
@@ -1,5 +1,4 @@
 #include "header_processor.h"
-#include "utility.h"
 
 namespace Envoy {
 namespace Extensions {

--- a/header-rewrite-filter/header_processor.cc
+++ b/header-rewrite-filter/header_processor.cc
@@ -49,8 +49,6 @@ namespace HeaderRewriteFilter {
             return absl::InvalidArgumentError("error parsing header values");
         }
 
-        // // parse condition expression and call evaluate conditions on the parsed expression
-        // const absl::Status status = evaluateCondition();
         return absl::OkStatus();
     }
 
@@ -86,7 +84,7 @@ namespace HeaderRewriteFilter {
     }
 
     void SetPathProcessor::evaluateCondition() {
-        // TODO: if processor is not null, call ConditionProcessor executeOperation; if it is null, return true
+        // if processor is not null, call ConditionProcessor executeOperation; if it is null, return true
         bool result = true;
         if (getConditionProcessor() != nullptr) {
             ENVOY_LOG_MISC(info, "executing set path's condition operation");
@@ -259,21 +257,14 @@ namespace HeaderRewriteFilter {
             }
         }
 
-        // validate number of operands and operators
-
-        // TODO: remove debug statements
-
-        // std::string debug = "second operand negated is " + std::to_string(operands_.at(1).second) + " , operator is " + std::to_string(int(operators_.at(0)));
-        // return absl::InvalidArgumentError(debug);
+        // TODO: validate number of operands and operators
         return absl::OkStatus();
-        // return (operators_.size() == operands_.size() - 1) ? absl::OkStatus() : absl::InvalidArgumentError("invalid condition");
     }
 
     bool ConditionProcessor::executeOperation() {
         if (operands_.size() == 1) {
             return operands_.at(0).second ? false : true; // TODO: remove mock value
         }
-
 
         bool result = true;
 

--- a/header-rewrite-filter/header_processor.cc
+++ b/header-rewrite-filter/header_processor.cc
@@ -5,14 +5,17 @@ namespace Extensions {
 namespace HttpFilters {
 namespace HeaderRewriteFilter {
 
-    absl::Status SetHeaderProcessor::parseOperation(std::vector<absl::string_view>& operation_expression) {
+    absl::Status SetHeaderProcessor::parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start) {
         if (operation_expression.size() < Utility::SET_HEADER_MIN_NUM_ARGUMENTS) {
             return absl::InvalidArgumentError("not enough arguments for set-header");
         }
 
+        // TODO: remove
+        start++;
+
         // parse key and call setKey
         try {
-            const absl::string_view key = operation_expression.at(2);
+            const absl::string_view key = operation_expression.at(2); // TODO: use start
             setKey(key);
         } catch (const std::exception& e) {
             // should never happen, range is checked above
@@ -23,6 +26,14 @@ namespace HeaderRewriteFilter {
         try {
             std::vector<std::string> vals;
             for(auto it = operation_expression.begin() + 3; it != operation_expression.end(); ++it) {
+                if (*it == "if") { // condition found
+                    setConditionProcessor(std::make_shared<ConditionProcessor>());
+                    const absl::Status status = getConditionProcessor()->parseOperation(operation_expression, it+1); // pass everything after the "if"
+                    if (status != absl::OkStatus()) {
+                        return status;
+                    }
+                    break;
+                }
                 vals.push_back(std::string{*it}); // could throw bad_alloc
             }
             setVals(vals);
@@ -30,17 +41,22 @@ namespace HeaderRewriteFilter {
             return absl::InvalidArgumentError("error parsing header values");
         }
 
-        // parse condition expression and call evaluate conditions on the parsed expression
-        const absl::Status status = evaluateCondition();
-        return status;
-    }
-
-    absl::Status SetHeaderProcessor::evaluateCondition() {
-        setCondition(true);
+        // // parse condition expression and call evaluate conditions on the parsed expression
+        // const absl::Status status = evaluateCondition();
         return absl::OkStatus();
     }
 
-    void SetHeaderProcessor::executeOperation(Http::RequestOrResponseHeaderMap& headers) const {
+    void SetHeaderProcessor::evaluateCondition() {
+        // TODO: if processor is not null, call ConditionProcessor executeOperation; if it is null, return true
+        bool result = true;
+        if (getConditionProcessor()) {
+            result = getConditionProcessor()->executeOperation();
+        }
+        setCondition(result);
+    }
+
+    void SetHeaderProcessor::executeOperation(Http::RequestOrResponseHeaderMap& headers) {
+        evaluateCondition();
         bool condition_result = getCondition(); // whether the condition is true or false
         const std::string key = getKey();
         const std::vector<std::string>& header_vals = getVals();
@@ -55,31 +71,44 @@ namespace HeaderRewriteFilter {
         }
     }
 
-     absl::Status SetPathProcessor::evaluateCondition() {
-        setCondition(true);
-        return absl::OkStatus();
+     void SetPathProcessor::evaluateCondition() {
+        // TODO: if processor is not null, call ConditionProcessor executeOperation; if it is null, return true
+        bool result = true;
+        if (getConditionProcessor()) {
+            result = getConditionProcessor()->executeOperation();
+        }
+        setCondition(result);
     }
 
-    absl::Status SetPathProcessor::parseOperation(std::vector<absl::string_view>& operation_expression) {
+    absl::Status SetPathProcessor::parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start) {
         if (operation_expression.size() < Utility::SET_PATH_MIN_NUM_ARGUMENTS) {
             return absl::InvalidArgumentError("not enough arguments for set-path");
         }
 
+        // TODO: remove
+        start++;
+
         // parse path and call setPath
         try {
-            absl::string_view request_path = operation_expression.at(2);
+            absl::string_view request_path = operation_expression.at(2); // TODO: use start
             setPath(request_path);
+
+            // TODO: if there's more args, evaluate them (should only be a condition)
+            // if condition found
+                    // declare a ConditionProcessor
+                    // call parseOperation on the processor
+
         } catch (const std::exception& e) {
             // should never happen, range is checked above
             return absl::InvalidArgumentError("error parsing request path argument");
         }
 
-        // parse condition expression and call evaluate conditions on the parsed expression
-        const absl::Status status = evaluateCondition();
-        return status;
+        // call evaluate conditions on the parsed expression
+        // const absl::Status status = evaluateCondition();
+        return absl::OkStatus();
     }
 
-    void SetPathProcessor::executeOperation(Http::RequestOrResponseHeaderMap& headers) const {
+    void SetPathProcessor::executeOperation(Http::RequestOrResponseHeaderMap& headers) {
         const bool condition_result = getCondition(); // whether the condition is true or false
         const std::string request_path = getPath();
 
@@ -102,13 +131,16 @@ namespace HeaderRewriteFilter {
         strings_to_compare_ = std::make_pair(first_string, second_string); 
     }
 
-    absl::Status SetBoolProcessor::parseOperation(std::vector<absl::string_view>& operation_expression) {
+    absl::Status SetBoolProcessor::parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start) {
         if (operation_expression.size() < Utility::SET_BOOL_MIN_NUM_ARGUMENTS) {
             return absl::InvalidArgumentError("not enough arguments for set-bool");
         }
 
+        // TODO: remove
+        start++;
+
         try {
-            absl::string_view bool_name = operation_expression.at(2);
+            absl::string_view bool_name = operation_expression.at(2); // TODO: use start
             setBoolName(bool_name);
 
             if (operation_expression.at(4) != "-m") {
@@ -158,6 +190,81 @@ namespace HeaderRewriteFilter {
         return result;
     }
 
+    absl::Status ConditionProcessor::parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start) {
+        // TODO: validate start pointer
+        const Utility::BooleanOperatorType start_type = Utility::StringToBooleanOperatorType(*start);
+
+        // conditional can't start with a binary operator
+        if (Utility::isBinaryOperator(start_type)) {
+            return absl::InvalidArgumentError("invalid condition -- condition must begin with '!' or an operand");
+        }
+
+        for (auto it = start; it != operation_expression.end();) {
+            const Utility::BooleanOperatorType operator_type = Utility::StringToBooleanOperatorType(*it);
+
+            // condition can't have two binary operators in a row
+            if (it != start) {
+                const Utility::BooleanOperatorType prev_operator_type = Utility::StringToBooleanOperatorType(*(it-1));
+                if (Utility::isBinaryOperator(operator_type) && Utility::isBinaryOperator(prev_operator_type)) {
+                    return absl::InvalidArgumentError("invalid condition -- cannot have two binary operators in a row");
+                }
+            }
+
+            // condition can't end with an operator
+            if (it+1 == operation_expression.end() && Utility::isOperator(operator_type)) {
+                return absl::InvalidArgumentError("invalid condition -- cannot have an operator at the end of the condition");
+            }
+
+            // parse operation type
+            if (Utility::isBinaryOperator(operator_type)) {
+                operators_.push_back(operator_type);
+                it++;
+            } else if (operator_type == Utility::BooleanOperatorType::Not) {
+                if (it + 1 == operation_expression.end()) {
+                    return absl::InvalidArgumentError("invalid condition -- must have operand after 'not'");
+                } else if (Utility::isOperator(Utility::StringToBooleanOperatorType(*(it+1)))) {
+                    return absl::InvalidArgumentError("invalid condition -- can't have an operator after 'not'");
+                }
+                operands_.push_back(std::pair<absl::string_view, bool>(*(it+1), true));
+                it += 2;
+            } else {
+                operands_.push_back(std::pair<absl::string_view, bool>(*it, false));
+                it++;
+            }
+        }
+
+        // validate number of operands and operators
+
+        // TODO: remove debug statements
+
+        // std::string debug = "second operand negated is " + std::to_string(operands_.at(1).second) + " , operator is " + std::to_string(int(operators_.at(0)));
+        // return absl::InvalidArgumentError(debug);
+        return absl::OkStatus();
+        // return (operators_.size() == operands_.size() - 1) ? absl::OkStatus() : absl::InvalidArgumentError("invalid condition");
+    }
+
+    bool ConditionProcessor::executeOperation() {
+        // return true;
+        if (operands_.size() == 1) {
+            return operands_.at(0).second ? false : true; // TODO: remove mock value
+        }
+
+        // return false;
+
+        bool result;
+
+        // evaluate first operation
+        result = Utility::evaluateExpression(operands_.at(0), operators_.at(0), operands_.at(1));
+
+        auto operators_it = operators_.begin() + 1;
+        auto operands_it = operands_.begin() + 2;
+
+        while (operators_it != operators_.end() && operands_it != operands_.end()) {
+            result = Utility::evaluateExpression(result, *operators_it, *operands_it);
+        }
+
+        return result;
+    }
 
 } // namespace HeaderRewriteFilter
 } // namespace HttpFilters

--- a/header-rewrite-filter/header_processor.cc
+++ b/header-rewrite-filter/header_processor.cc
@@ -96,8 +96,8 @@ namespace HeaderRewriteFilter {
 
 
     void SetBoolProcessor::setStringsToCompare(std::pair<absl::string_view, absl::string_view> strings_to_compare) {
-        std::string first_string = std::string(strings_to_compare.first);
-        std::string second_string = std::string(strings_to_compare.second);
+        std::string first_string(strings_to_compare.first);
+        std::string second_string(strings_to_compare.second);
 
         strings_to_compare_ = std::make_pair(first_string, second_string); 
     }

--- a/header-rewrite-filter/header_processor.cc
+++ b/header-rewrite-filter/header_processor.cc
@@ -29,7 +29,6 @@ namespace HeaderRewriteFilter {
             std::vector<std::string> vals;
             for(auto it = operation_expression.begin() + 3; it != operation_expression.end(); ++it) {
                 if (*it == "if") { // condition found
-                    ENVOY_LOG_MISC(info, "condition found"); // TODO: remove debug
 
                     if (it + 1 == operation_expression.end()) {
                     return absl::InvalidArgumentError("empty condition provided");
@@ -56,17 +55,13 @@ namespace HeaderRewriteFilter {
         // TODO: if processor is not null, call ConditionProcessor executeOperation; if it is null, return true
         bool result = true;
         if (getConditionProcessor()) {
-            ENVOY_LOG_MISC(info, "start executing condition");
             result = getConditionProcessor()->executeOperation();
         }
-        ENVOY_LOG_MISC(info, "finish executing condition");
         setCondition(result);
     }
 
     void SetHeaderProcessor::executeOperation(Http::RequestOrResponseHeaderMap& headers) {
-        ENVOY_LOG_MISC(info, "start evaluating condition");
         evaluateCondition();
-        ENVOY_LOG_MISC(info, "finish evaluating condition");
         bool condition_result = getCondition(); // whether the condition is true or false
         const std::string key = getKey();
         const std::vector<std::string>& header_vals = getVals();
@@ -79,18 +74,14 @@ namespace HeaderRewriteFilter {
         for (auto const& header_val : header_vals) {
             headers.addCopy(Http::LowerCaseString(key), header_val); // should never return an error
         }
-
-        ENVOY_LOG_MISC(info, "added header");
     }
 
     void SetPathProcessor::evaluateCondition() {
         // if processor is not null, call ConditionProcessor executeOperation; if it is null, return true
         bool result = true;
         if (getConditionProcessor() != nullptr) {
-            ENVOY_LOG_MISC(info, "executing set path's condition operation");
             result = getConditionProcessor()->executeOperation();
         } else {
-            ENVOY_LOG_MISC(info, "no set path condition detected");
         }
         setCondition(result);
     }

--- a/header-rewrite-filter/header_processor.cc
+++ b/header-rewrite-filter/header_processor.cc
@@ -141,6 +141,23 @@ namespace HeaderRewriteFilter {
         return absl::OkStatus();
     }
 
+    bool SetBoolProcessor::executeOperation() const {
+        const Utility::MatchType match_type = getMatchType();
+
+        bool result;
+
+        switch (match_type) {
+            case Utility::MatchType::Exact:
+                result = (getStringsToCompare().first == getStringsToCompare().second);
+                break;
+            // TODO: implement rest of the match cases
+            default:
+                result = false;
+        }
+
+        return result;
+    }
+
 
 } // namespace HeaderRewriteFilter
 } // namespace HttpFilters

--- a/header-rewrite-filter/header_processor.cc
+++ b/header-rewrite-filter/header_processor.cc
@@ -302,6 +302,7 @@ namespace HeaderRewriteFilter {
             return absl::OkStatus();
 
         } catch (std::exception& e) { // fails gracefully if a faulty map access occurs
+            std::cout << e.what();
             return absl::InvalidArgumentError("failed to process condition");
         }
     }

--- a/header-rewrite-filter/header_processor.h
+++ b/header-rewrite-filter/header_processor.h
@@ -70,10 +70,10 @@ class SetBoolProcessor : public Processor {
 public:
   virtual ~SetBoolProcessor() {}
   virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression);
-  // virtual void executeOperation() const;
+  virtual bool executeOperation() const;
+  const std::string& getBoolName() const { return bool_name_; }
 
 private:
-  const std::string& getBoolName() const { return bool_name_; }
   void setBoolName(absl::string_view bool_name) { bool_name_ = std::string(bool_name); }
 
   const std::pair<std::string, std::string>& getStringsToCompare() const { return strings_to_compare_; }

--- a/header-rewrite-filter/header_processor.h
+++ b/header-rewrite-filter/header_processor.h
@@ -36,7 +36,7 @@ private:
   Utility::MatchType getMatchType() const { return match_type_; }
   void setMatchType(Utility::MatchType match_type) { match_type_ = match_type; }
 
-  std::string bool_name_; // TODO: might only need to store this in the map
+  std::string bool_name_;
   std::pair<std::string, std::string> strings_to_compare_;
   Utility::MatchType match_type_;
 };

--- a/header-rewrite-filter/header_processor.h
+++ b/header-rewrite-filter/header_processor.h
@@ -51,7 +51,6 @@ public:
   virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start);
   absl::Status executeOperation(SetBoolProcessorMapSharedPtr set_bool_processors);
 
-  // TODO: remove this?
   SetBoolProcessorMapSharedPtr getBoolProcessors() { return set_bool_processors_; }
   void setBoolProccessors(SetBoolProcessorMapSharedPtr bool_processors) { set_bool_processors_ = bool_processors; }
   bool getConditionResult() const { return condition_; }

--- a/header-rewrite-filter/header_processor.h
+++ b/header-rewrite-filter/header_processor.h
@@ -49,17 +49,18 @@ public:
   ConditionProcessor() {}
   virtual ~ConditionProcessor() {}
   virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start);
-  bool executeOperation(SetBoolProcessorMapSharedPtr set_bool_processors);
+  absl::Status executeOperation(SetBoolProcessorMapSharedPtr set_bool_processors);
 
   // TODO: remove this?
   SetBoolProcessorMapSharedPtr getBoolProcessors() { return set_bool_processors_; }
   void setBoolProccessors(SetBoolProcessorMapSharedPtr bool_processors) { set_bool_processors_ = bool_processors; }
+  bool getConditionResult() const { return condition_; }
 
 private:
   std::vector<Utility::BooleanOperatorType> operators_;
   std::vector<std::pair<absl::string_view, bool>> operands_; // operand and whether that operand is negated
   SetBoolProcessorMapSharedPtr set_bool_processors_ = nullptr;
-  bool isTrue_; // not needed? can directly return the result without storing it
+  bool condition_;
 };
 
 using ConditionProcessorSharedPtr = std::shared_ptr<ConditionProcessor>;
@@ -69,8 +70,8 @@ public:
   HeaderProcessor() {}
   virtual ~HeaderProcessor() {}
   virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start) = 0;
-  virtual void executeOperation(Http::RequestOrResponseHeaderMap& headers, SetBoolProcessorMapSharedPtr bool_processors) = 0;
-  virtual void evaluateCondition(); // TODO: implement this in parent class
+  virtual absl::Status executeOperation(Http::RequestOrResponseHeaderMap& headers, SetBoolProcessorMapSharedPtr bool_processors) = 0;
+  virtual absl::Status evaluateCondition();
   bool getCondition() const { return condition_; }
   void setCondition(bool result) { condition_ = result; }
   void setConditionProcessor(ConditionProcessorSharedPtr condition_processor) { condition_processor_ = condition_processor; }
@@ -86,7 +87,7 @@ public:
   SetHeaderProcessor() {}
   virtual ~SetHeaderProcessor() {}
   virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start);
-  virtual void executeOperation(Http::RequestOrResponseHeaderMap& headers, SetBoolProcessorMapSharedPtr bool_processors);
+  virtual absl::Status executeOperation(Http::RequestOrResponseHeaderMap& headers, SetBoolProcessorMapSharedPtr bool_processors);
 private:
   // Note: the values returned by these functions must not outlive the SetHeaderProcessor object
   const std::string& getKey() const { return header_key_; }
@@ -104,7 +105,7 @@ public:
   SetPathProcessor() {}
   virtual ~SetPathProcessor() {}
   virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start);
-  virtual void executeOperation(Http::RequestOrResponseHeaderMap& headers, SetBoolProcessorMapSharedPtr bool_processors);
+  virtual absl::Status executeOperation(Http::RequestOrResponseHeaderMap& headers, SetBoolProcessorMapSharedPtr bool_processors);
 
 private:
   const std::string& getPath() const { return request_path_; }

--- a/header-rewrite-filter/header_processor.h
+++ b/header-rewrite-filter/header_processor.h
@@ -27,7 +27,7 @@ public:
 private:
   std::vector<Utility::BooleanOperatorType> operators_;
   std::vector<std::pair<absl::string_view, bool>> operands_; // operand and whether that operand is negated
-  bool isTrue_; // not needed? can directly return the result without storing it
+  bool isTrue_; // Note: will be used when connecting ConditionProcessor to SetBoolProcessor
 };
 
 using ConditionProcessorSharedPtr = std::shared_ptr<ConditionProcessor>;
@@ -99,7 +99,7 @@ private:
   Utility::MatchType getMatchType() const { return match_type_; }
   void setMatchType(Utility::MatchType match_type) { match_type_ = match_type; }
 
-  std::string bool_name_; // TODO: might only need to store this in the map
+  std::string bool_name_;
   std::pair<std::string, std::string> strings_to_compare_;
   Utility::MatchType match_type_;
 };

--- a/header-rewrite-filter/header_processor.h
+++ b/header-rewrite-filter/header_processor.h
@@ -70,9 +70,18 @@ class SetBoolProcessor : public Processor {
 public:
   virtual ~SetBoolProcessor() {}
   virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression);
-  virtual void executeOperation() const;
+  // virtual void executeOperation() const;
 
 private:
+  const std::string& getBoolName() const { return bool_name_; }
+  void setBoolName(absl::string_view bool_name) { bool_name_ = std::string(bool_name); }
+
+  const std::pair<std::string, std::string>& getStringsToCompare() const { return strings_to_compare_; }
+  void setStringsToCompare(std::pair<absl::string_view, absl::string_view> strings_to_compare);
+
+  Utility::MatchType getMatchType() const { return match_type_; }
+  void setMatchType(Utility::MatchType match_type) { match_type_ = match_type; }
+
   std::string bool_name_; // TODO: might only need to store this in the map
   std::pair<std::string, std::string> strings_to_compare_;
   Utility::MatchType match_type_;

--- a/header-rewrite-filter/header_processor.h
+++ b/header-rewrite-filter/header_processor.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "utility.h"
+
 #include "source/extensions/filters/http/common/pass_through_filter.h"
 
 #include <string>
@@ -10,7 +12,13 @@ namespace Extensions {
 namespace HttpFilters {
 namespace HeaderRewriteFilter {
 
-class HeaderProcessor {
+class Processor {
+public:
+  virtual ~Processor() {}
+  virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression) = 0;
+};
+
+class HeaderProcessor : public Processor {
 public:
   virtual ~HeaderProcessor() {}
   virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression) = 0;
@@ -56,6 +64,18 @@ private:
   void setPath(absl::string_view path) { request_path_ = std::string(path); }
 
   std::string request_path_; // path to set
+};
+
+class SetBoolProcessor : public Processor {
+public:
+  virtual ~SetBoolProcessor() {}
+  virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression);
+  virtual void executeOperation() const;
+
+private:
+  std::string bool_name_; // TODO: might only need to store this in the map
+  std::pair<std::string, std::string> strings_to_compare_;
+  Utility::MatchType match_type_;
 };
 
 } // namespace HeaderRewriteFilter

--- a/header-rewrite-filter/header_processor.h
+++ b/header-rewrite-filter/header_processor.h
@@ -15,29 +15,46 @@ namespace HeaderRewriteFilter {
 class Processor {
 public:
   virtual ~Processor() {}
-  virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression) = 0;
+  virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start) = 0;
 };
+
+class ConditionProcessor : public Processor {
+public:
+  virtual ~ConditionProcessor() {}
+  virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start);
+  bool executeOperation();
+
+private:
+  std::vector<Utility::BooleanOperatorType> operators_;
+  std::vector<std::pair<absl::string_view, bool>> operands_; // operand and whether that operand is negated
+  bool isTrue_; // not needed? can directly return the result without storing it
+};
+
+using ConditionProcessorSharedPtr = std::shared_ptr<ConditionProcessor>;
 
 class HeaderProcessor : public Processor {
 public:
   virtual ~HeaderProcessor() {}
-  virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression) = 0;
-  virtual void executeOperation(Http::RequestOrResponseHeaderMap& headers) const = 0;
-  virtual absl::Status evaluateCondition() = 0;
+  virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start) = 0;
+  virtual void executeOperation(Http::RequestOrResponseHeaderMap& headers) = 0;
+  virtual void evaluateCondition() = 0; // TODO: implement this in parent class
   bool getCondition() const { return condition_; }
   void setCondition(bool result) { condition_ = result; }
+  void setConditionProcessor(ConditionProcessorSharedPtr condition_processor) { condition_processor_ = condition_processor; }
+  ConditionProcessorSharedPtr getConditionProcessor() { return condition_processor_; }
 
 protected:
   bool condition_;
+  ConditionProcessorSharedPtr condition_processor_ = nullptr;
 };
 
 class SetHeaderProcessor : public HeaderProcessor {
 public:
   SetHeaderProcessor() {}
   virtual ~SetHeaderProcessor() {}
-  virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression);
-  virtual void executeOperation(Http::RequestOrResponseHeaderMap& headers) const;
-  virtual absl::Status evaluateCondition(); // TODO: will need to pass http-related metadata in order to evaluate dynamic values
+  virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start);
+  virtual void executeOperation(Http::RequestOrResponseHeaderMap& headers);
+  virtual void evaluateCondition(); // TODO: will need to pass http-related metadata in order to evaluate dynamic values
 
 private:
   // Note: the values returned by these functions must not outlive the SetHeaderProcessor object
@@ -55,9 +72,9 @@ class SetPathProcessor : public HeaderProcessor {
 public:
   SetPathProcessor() {}
   virtual ~SetPathProcessor() {}
-  virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression);
-  virtual void executeOperation(Http::RequestOrResponseHeaderMap& headers) const;
-  virtual absl::Status evaluateCondition(); // TODO: possibly combine with SetHeader implementation and move code into HeaderProcessor
+  virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start);
+  virtual void executeOperation(Http::RequestOrResponseHeaderMap& headers);
+  virtual void evaluateCondition(); // TODO: possibly combine with SetHeader implementation and move code into HeaderProcessor
 
 private:
   const std::string& getPath() const { return request_path_; }
@@ -69,7 +86,7 @@ private:
 class SetBoolProcessor : public Processor {
 public:
   virtual ~SetBoolProcessor() {}
-  virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression);
+  virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start);
   virtual bool executeOperation() const;
   const std::string& getBoolName() const { return bool_name_; }
 

--- a/header-rewrite-filter/header_rewrite.cc
+++ b/header-rewrite-filter/header_rewrite.cc
@@ -128,7 +128,6 @@ Http::FilterHeadersStatus HttpHeaderRewriteFilter::decodeHeaders(Http::RequestHe
     }
   }
 
-
   return Http::FilterHeadersStatus::Continue;
 }
 

--- a/header-rewrite-filter/header_rewrite.cc
+++ b/header-rewrite-filter/header_rewrite.cc
@@ -68,7 +68,7 @@ HttpHeaderRewriteFilter::HttpHeaderRewriteFilter(HttpHeaderRewriteFilterConfigSh
       case Utility::OperationType::SetBool:
       {
         SetBoolProcessorUniquePtr processor = std::make_unique<SetBoolProcessor>();
-        const absl::Status status = processor->parseOperation(tokens);
+        const absl::Status status = processor->parseOperation(tokens, tokens.begin());
         if (!status.ok()) {
           fail(status.message());
           setError();
@@ -86,7 +86,7 @@ HttpHeaderRewriteFilter::HttpHeaderRewriteFilter(HttpHeaderRewriteFilterConfigSh
 
     // parse operation
     if (processor) {
-      const absl::Status status = processor->parseOperation(tokens);
+      const absl::Status status = processor->parseOperation(tokens, tokens.begin());
       if (!status.ok()) {
         fail(status.message());
         setError();

--- a/header-rewrite-filter/header_rewrite.cc
+++ b/header-rewrite-filter/header_rewrite.cc
@@ -71,13 +71,21 @@ HttpHeaderRewriteFilter::HttpHeaderRewriteFilter(HttpHeaderRewriteFilterConfigSh
       case Utility::OperationType::SetBool:
       {
         SetBoolProcessorSharedPtr processor = std::make_unique<SetBoolProcessor>();
+        const std::string boolName(tokens.at(2));
         const absl::Status status = processor->parseOperation(tokens, tokens.begin());
+
         if (!status.ok()) {
           fail(status.message());
           setError();
           return;
         }
-        set_bool_processors_->insert({processor->getBoolName(), std::move(processor)});
+        // make sure this boolean variable doesn't already exist in the map
+        if (set_bool_processors_->find(boolName) != set_bool_processors_->end()) {
+          fail("redefinition of boolean variable");
+          setError();
+          return;
+        }
+        set_bool_processors_->insert({boolName, std::move(processor)});
         break;
       }
       default:

--- a/header-rewrite-filter/header_rewrite.cc
+++ b/header-rewrite-filter/header_rewrite.cc
@@ -120,8 +120,11 @@ Http::FilterHeadersStatus HttpHeaderRewriteFilter::decodeHeaders(Http::RequestHe
 
   // execute each operation
   for (auto const& processor : request_header_processors_) {
+    ENVOY_LOG_MISC(info, "executing request operation");
     processor->executeOperation(headers);
   }
+
+  ENVOY_LOG_MISC(info, "finished executing response operations");
 
   return Http::FilterHeadersStatus::Continue;
 }
@@ -134,13 +137,16 @@ Http::FilterHeadersStatus HttpHeaderRewriteFilter::encodeHeaders(Http::ResponseH
 
   // execute each operation
   for (auto const& processor : response_header_processors_) {
+    ENVOY_LOG_MISC(info, "executing response operation");
     processor->executeOperation(headers);
   }
 
+    ENVOY_LOG_MISC(info, "finished executing response operation");
+
   // TODO: remove debug statement
-  // const bool result = set_bool_processors_.at("mock_bool")->executeOperation();
-  // if (result)
-  //   ENVOY_LOG_MISC(info, "match found!");
+  const bool result = set_bool_processors_.at("mock_bool")->executeOperation();
+  if (result)
+    ENVOY_LOG_MISC(info, "match found!");
 
   return Http::FilterHeadersStatus::Continue;
 }

--- a/header-rewrite-filter/header_rewrite.cc
+++ b/header-rewrite-filter/header_rewrite.cc
@@ -122,8 +122,10 @@ Http::FilterHeadersStatus HttpHeaderRewriteFilter::decodeHeaders(Http::RequestHe
 
   // execute each operation
   for (auto const& processor : request_header_processors_) {
-    if (processor->executeOperation(headers, set_bool_processors_) != absl::OkStatus()) {
-      ENVOY_LOG_MISC(info, "error executing an operation, skipping filter"); // TODO: some ops are executed, do any ops depend on previous ones?
+    const absl::Status status = processor->executeOperation(headers, set_bool_processors_);
+    if (status != absl::OkStatus()) {
+      ENVOY_LOG_MISC(info, "error executing an operation on request side, skipping filter");
+      ENVOY_LOG_MISC(info, status.message());
       return Http::FilterHeadersStatus::Continue;
     }
   }
@@ -139,8 +141,10 @@ Http::FilterHeadersStatus HttpHeaderRewriteFilter::encodeHeaders(Http::ResponseH
 
   // execute each operation
   for (auto const& processor : response_header_processors_) {
-    if (processor->executeOperation(headers, set_bool_processors_) != absl::OkStatus()) {
-      ENVOY_LOG_MISC(info, "error executing an operation, skipping filter");
+    const absl::Status status = processor->executeOperation(headers, set_bool_processors_);
+    if (status != absl::OkStatus()) {
+      ENVOY_LOG_MISC(info, "error executing an operation on response side, skipping filter");
+      ENVOY_LOG_MISC(info, status.message());
       return Http::FilterHeadersStatus::Continue;
     }
   }

--- a/header-rewrite-filter/header_rewrite.cc
+++ b/header-rewrite-filter/header_rewrite.cc
@@ -120,11 +120,8 @@ Http::FilterHeadersStatus HttpHeaderRewriteFilter::decodeHeaders(Http::RequestHe
 
   // execute each operation
   for (auto const& processor : request_header_processors_) {
-    ENVOY_LOG_MISC(info, "executing request operation");
     processor->executeOperation(headers);
   }
-
-  ENVOY_LOG_MISC(info, "finished executing response operations");
 
   return Http::FilterHeadersStatus::Continue;
 }
@@ -137,16 +134,8 @@ Http::FilterHeadersStatus HttpHeaderRewriteFilter::encodeHeaders(Http::ResponseH
 
   // execute each operation
   for (auto const& processor : response_header_processors_) {
-    ENVOY_LOG_MISC(info, "executing response operation");
     processor->executeOperation(headers);
   }
-
-    ENVOY_LOG_MISC(info, "finished executing response operation");
-
-  // TODO: remove debug statement
-  const bool result = set_bool_processors_.at("mock_bool")->executeOperation();
-  if (result)
-    ENVOY_LOG_MISC(info, "match found!");
 
   return Http::FilterHeadersStatus::Continue;
 }

--- a/header-rewrite-filter/header_rewrite.h
+++ b/header-rewrite-filter/header_rewrite.h
@@ -28,7 +28,7 @@ private:
 
 using HttpHeaderRewriteFilterConfigSharedPtr = std::shared_ptr<HttpHeaderRewriteFilterConfig>;
 using HeaderProcessorUniquePtr = std::unique_ptr<HeaderProcessor>;
-using SetBoolProcessorUniquePtr = std::unique_ptr<SetBoolProcessor>;
+using SetBoolProcessorSharedPtr = std::shared_ptr<SetBoolProcessor>;
 
 class HttpHeaderRewriteFilter : public Http::PassThroughFilter {
 public:
@@ -51,7 +51,7 @@ private:
   std::vector<HeaderProcessorUniquePtr> response_header_processors_;
 
   // set_bool processors
-  std::unordered_map<std::string, SetBoolProcessorUniquePtr> set_bool_processors_;
+  std::unordered_map<std::string, SetBoolProcessorSharedPtr> set_bool_processors_;
 
   const Http::LowerCaseString headerKey() const;
   const std::string headerValue() const;

--- a/header-rewrite-filter/header_rewrite.h
+++ b/header-rewrite-filter/header_rewrite.h
@@ -49,8 +49,7 @@ private:
   std::vector<HeaderProcessorUniquePtr> request_header_processors_;
   std::vector<HeaderProcessorUniquePtr> response_header_processors_;
 
-  // set of accepted operations
-  std::unordered_set<std::string> operations_;
+  // TODO: add bool map
 
   const Http::LowerCaseString headerKey() const;
   const std::string headerValue() const;

--- a/header-rewrite-filter/header_rewrite.h
+++ b/header-rewrite-filter/header_rewrite.h
@@ -28,6 +28,7 @@ private:
 
 using HttpHeaderRewriteFilterConfigSharedPtr = std::shared_ptr<HttpHeaderRewriteFilterConfig>;
 using HeaderProcessorUniquePtr = std::unique_ptr<HeaderProcessor>;
+using SetBoolProcessorUniquePtr = std::unique_ptr<SetBoolProcessor>;
 
 class HttpHeaderRewriteFilter : public Http::PassThroughFilter {
 public:
@@ -49,7 +50,8 @@ private:
   std::vector<HeaderProcessorUniquePtr> request_header_processors_;
   std::vector<HeaderProcessorUniquePtr> response_header_processors_;
 
-  // TODO: add bool map
+  // set_bool processors
+  std::unordered_map<std::string, SetBoolProcessorUniquePtr> set_bool_processors_;
 
   const Http::LowerCaseString headerKey() const;
   const std::string headerValue() const;

--- a/header-rewrite-filter/header_rewrite.h
+++ b/header-rewrite-filter/header_rewrite.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <string>
-// #include <unordered_set>
 
 #include "header_processor.h"
 

--- a/header-rewrite-filter/header_rewrite.h
+++ b/header-rewrite-filter/header_rewrite.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <string>
-#include <unordered_set>
+// #include <unordered_set>
 
 #include "header_processor.h"
 
@@ -29,6 +29,7 @@ private:
 using HttpHeaderRewriteFilterConfigSharedPtr = std::shared_ptr<HttpHeaderRewriteFilterConfig>;
 using HeaderProcessorUniquePtr = std::unique_ptr<HeaderProcessor>;
 using SetBoolProcessorSharedPtr = std::shared_ptr<SetBoolProcessor>;
+using SetBoolProcessorMapSharedPtr = std::shared_ptr<std::unordered_map<std::string, SetBoolProcessorSharedPtr>>;
 
 class HttpHeaderRewriteFilter : public Http::PassThroughFilter {
 public:
@@ -51,7 +52,7 @@ private:
   std::vector<HeaderProcessorUniquePtr> response_header_processors_;
 
   // set_bool processors
-  std::unordered_map<std::string, SetBoolProcessorSharedPtr> set_bool_processors_;
+  SetBoolProcessorMapSharedPtr set_bool_processors_;
 
   const Http::LowerCaseString headerKey() const;
   const std::string headerValue() const;

--- a/header-rewrite-filter/utility.cc
+++ b/header-rewrite-filter/utility.cc
@@ -30,6 +30,50 @@ MatchType StringToMatchType(absl::string_view match) {
     }
 }
 
+BooleanOperatorType StringToBooleanOperatorType(absl::string_view bool_operator) {
+    if (bool_operator == "and") {
+        return BooleanOperatorType::And;
+    } else if (bool_operator == "or") {
+        return BooleanOperatorType::Or;
+    } else if (bool_operator == "not") {
+        return BooleanOperatorType::Not;
+    } else {
+        return BooleanOperatorType::None;
+    }
+}
+
+bool isOperator(BooleanOperatorType operator_type) {
+    return (operator_type == BooleanOperatorType::And || operator_type == BooleanOperatorType::Or || operator_type == BooleanOperatorType::Not);
+}
+
+bool isBinaryOperator(BooleanOperatorType operator_type) {
+    return (operator_type == BooleanOperatorType::And || operator_type == BooleanOperatorType::Or);
+}
+
+// bool isOperand(BooleanOperatorType operator_type) {
+//     return operator_type == BooleanOperatorType::None;
+// }
+
+bool evaluateExpression(std::pair<absl::string_view, bool> operand1, BooleanOperatorType operator_val, std::pair<absl::string_view, bool> operand2) {
+    // TODO: remove mock values
+    
+    bool op1 = operand1.second ? !true : true;
+    bool op2 = operand2.second ? !true : true;
+
+    if (operator_val == BooleanOperatorType::And) return op1 && op2;
+    return op1 || op2;
+}
+
+bool evaluateExpression(bool operand1, BooleanOperatorType operator_val, std::pair<absl::string_view, bool> operand2) {
+    // TODO: remove mock values
+
+    bool op2 = operand2.second ? !true : true;
+
+    if (operator_val == BooleanOperatorType::And) return operand1 && op2;
+    return operand1 || op2;
+}
+
+
 } // namespace Utility
 } // namespace HeaderRewriteFilter
 } // namespace HttpFilters

--- a/header-rewrite-filter/utility.cc
+++ b/header-rewrite-filter/utility.cc
@@ -50,10 +50,6 @@ bool isBinaryOperator(BooleanOperatorType operator_type) {
     return (operator_type == BooleanOperatorType::And || operator_type == BooleanOperatorType::Or);
 }
 
-// bool isOperand(BooleanOperatorType operator_type) {
-//     return operator_type == BooleanOperatorType::None;
-// }
-
 bool evaluateExpression(std::pair<absl::string_view, bool> operand1, BooleanOperatorType operator_val, std::pair<absl::string_view, bool> operand2) {
     // TODO: remove mock values
     

--- a/header-rewrite-filter/utility.cc
+++ b/header-rewrite-filter/utility.cc
@@ -54,23 +54,21 @@ bool isBinaryOperator(BooleanOperatorType operator_type) {
 //     return operator_type == BooleanOperatorType::None;
 // }
 
-bool evaluateExpression(std::pair<absl::string_view, bool> operand1, BooleanOperatorType operator_val, std::pair<absl::string_view, bool> operand2) {
-    // TODO: remove mock values
+// bool evaluateExpression(std::pair<absl::string_view, bool> operand1, BooleanOperatorType operator_val, std::pair<absl::string_view, bool> operand2) {
+//     // TODO: add error checks for invalid access
     
-    bool op1 = operand1.second ? !true : true;
-    bool op2 = operand2.second ? !true : true;
+//     bool op1 = operand1.second ? !(bool_processors->at(operand1.first)->executeOperation()) : bool_processors->at(operand1.first)->executeOperation();
+//     bool op2 = operand2.second ? !(bool_processors->at(operand2.first)->executeOperation()) : bool_processors->at(operand2.first)->executeOperation();
 
-    if (operator_val == BooleanOperatorType::And) return op1 && op2;
-    return op1 || op2;
-}
+//     if (operator_val == BooleanOperatorType::And) return op1 && op2;
+//     return op1 || op2;
+// }
 
-bool evaluateExpression(bool operand1, BooleanOperatorType operator_val, std::pair<absl::string_view, bool> operand2) {
-    // TODO: remove mock values
+bool evaluateExpression(bool operand1, BooleanOperatorType operator_val, bool operand2) {
+    // TODO: add error checks for invalid access
 
-    bool op2 = operand2.second ? !true : true;
-
-    if (operator_val == BooleanOperatorType::And) return operand1 && op2;
-    return operand1 || op2;
+    if (operator_val == BooleanOperatorType::And) return operand1 && operand2;
+    return operand1 || operand2;
 }
 
 

--- a/header-rewrite-filter/utility.cc
+++ b/header-rewrite-filter/utility.cc
@@ -51,8 +51,6 @@ bool isBinaryOperator(BooleanOperatorType operator_type) {
 }
 
 bool evaluateExpression(bool operand1, BooleanOperatorType operator_val, bool operand2) {
-    // TODO: add error checks for invalid access
-
     if (operator_val == BooleanOperatorType::And) return operand1 && operand2;
     return operand1 || operand2;
 }

--- a/header-rewrite-filter/utility.cc
+++ b/header-rewrite-filter/utility.cc
@@ -11,8 +11,20 @@ namespace Utility {
         return OperationType::SetHeader;
     } else if (operation == "set-path") {
         return OperationType::SetPath;
+    } else if (operation == "set-bool") {
+        return OperationType::SetBool;
     } else {
         return OperationType::InvalidOperation;
+    }
+}
+
+MatchType StringToMatchType(absl::string_view match) {
+    if (match == "str") {
+        return MatchType::Exact;
+    } else if (match == "sub") {
+        return MatchType::Substr;
+    } else {
+        return MatchType::InvalidMatchType;
     }
 }
 

--- a/header-rewrite-filter/utility.cc
+++ b/header-rewrite-filter/utility.cc
@@ -19,11 +19,11 @@ namespace Utility {
 }
 
 MatchType StringToMatchType(absl::string_view match) {
-    if (match == "str") {
+    if (match == MATCH_TYPE_EXACT) {
         return MatchType::Exact;
-    } else if (match == "sub") {
+    } else if (match == MATCH_TYPE_SUBSTR) {
         return MatchType::Substr;
-    } else if (match == "found") {
+    } else if (match == MATCH_TYPE_FOUND) {
         return MatchType::Found;
     } else {
         return MatchType::InvalidMatchType;

--- a/header-rewrite-filter/utility.cc
+++ b/header-rewrite-filter/utility.cc
@@ -23,6 +23,8 @@ MatchType StringToMatchType(absl::string_view match) {
         return MatchType::Exact;
     } else if (match == "sub") {
         return MatchType::Substr;
+    } else if (match == "found") {
+        return MatchType::Found;
     } else {
         return MatchType::InvalidMatchType;
     }

--- a/header-rewrite-filter/utility.h
+++ b/header-rewrite-filter/utility.h
@@ -11,11 +11,15 @@ namespace Utility {
 constexpr uint8_t MIN_NUM_ARGUMENTS = 2;
 constexpr uint8_t SET_HEADER_MIN_NUM_ARGUMENTS = 4;
 constexpr uint8_t SET_PATH_MIN_NUM_ARGUMENTS = 3;
-constexpr uint8_t SET_BOOL_MIN_NUM_ARGUMENTS = 5;
+constexpr uint8_t SET_BOOL_MIN_NUM_ARGUMENTS = 6;
 
 constexpr absl::string_view HTTP_REQUEST = "http-request";
 constexpr absl::string_view HTTP_RESPONSE = "http-response";
 constexpr absl::string_view HTTP_REQUEST_RESPONSE = "http";
+
+constexpr absl::string_view MATCH_TYPE_EXACT = "str";
+constexpr absl::string_view MATCH_TYPE_SUBSTR = "sub";
+constexpr absl::string_view MATCH_TYPE_FOUND = "found";
 
 enum class OperationType : int {
   SetHeader,

--- a/header-rewrite-filter/utility.h
+++ b/header-rewrite-filter/utility.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+#include <unordered_map>
 #include "absl/strings/string_view.h"
 
 namespace Envoy {
@@ -44,8 +46,8 @@ BooleanOperatorType StringToBooleanOperatorType(absl::string_view bool_operator)
 
 bool isOperator(BooleanOperatorType operator_type);
 bool isBinaryOperator(BooleanOperatorType operator_type);
-bool evaluateExpression(std::pair<absl::string_view, bool> operand1, BooleanOperatorType operator_val, std::pair<absl::string_view, bool> operand2);
-bool evaluateExpression(bool operand1, BooleanOperatorType operator_val, std::pair<absl::string_view, bool> operand2);
+// bool evaluateExpression(std::pair<absl::string_view, bool> operand1, BooleanOperatorType operator_val, std::pair<absl::string_view, bool> operand2);
+bool evaluateExpression(bool operand1, BooleanOperatorType operator_val, bool operand2);
 
 // bool isOperand(BooleanOperatorType operator_type);
 

--- a/header-rewrite-filter/utility.h
+++ b/header-rewrite-filter/utility.h
@@ -50,7 +50,6 @@ BooleanOperatorType StringToBooleanOperatorType(absl::string_view bool_operator)
 
 bool isOperator(BooleanOperatorType operator_type);
 bool isBinaryOperator(BooleanOperatorType operator_type);
-// bool evaluateExpression(std::pair<absl::string_view, bool> operand1, BooleanOperatorType operator_val, std::pair<absl::string_view, bool> operand2);
 bool evaluateExpression(bool operand1, BooleanOperatorType operator_val, bool operand2);
 
 } // namespace Utility

--- a/header-rewrite-filter/utility.h
+++ b/header-rewrite-filter/utility.h
@@ -14,14 +14,23 @@ constexpr uint8_t SET_PATH_MIN_NUM_ARGUMENTS = 3;
 
 constexpr absl::string_view HTTP_REQUEST = "http-request";
 constexpr absl::string_view HTTP_RESPONSE = "http-response";
+constexpr absl::string_view HTTP_REQUEST_RESPONSE = "http";
 
 enum class OperationType : int {
   SetHeader,
   SetPath,
+  SetBool,
   InvalidOperation,
 };
 
+enum class MatchType : int {
+  Exact,
+  Substr,
+  InvalidMatchType,
+};
+
 OperationType StringToOperationType(absl::string_view operation);
+MatchType StringToMatchType(absl::string_view match);
 
 } // namespace Utility
 } // namespace HeaderRewriteFilter

--- a/header-rewrite-filter/utility.h
+++ b/header-rewrite-filter/utility.h
@@ -31,8 +31,23 @@ enum class MatchType : int {
   InvalidMatchType,
 };
 
+enum class BooleanOperatorType : int {
+  And,
+  Or,
+  Not,
+  None,
+};
+
 OperationType StringToOperationType(absl::string_view operation);
 MatchType StringToMatchType(absl::string_view match);
+BooleanOperatorType StringToBooleanOperatorType(absl::string_view bool_operator);
+
+bool isOperator(BooleanOperatorType operator_type);
+bool isBinaryOperator(BooleanOperatorType operator_type);
+bool evaluateExpression(std::pair<absl::string_view, bool> operand1, BooleanOperatorType operator_val, std::pair<absl::string_view, bool> operand2);
+bool evaluateExpression(bool operand1, BooleanOperatorType operator_val, std::pair<absl::string_view, bool> operand2);
+
+// bool isOperand(BooleanOperatorType operator_type);
 
 } // namespace Utility
 } // namespace HeaderRewriteFilter

--- a/header-rewrite-filter/utility.h
+++ b/header-rewrite-filter/utility.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <memory>
-#include <unordered_map>
 #include "absl/strings/string_view.h"
 
 namespace Envoy {

--- a/header-rewrite-filter/utility.h
+++ b/header-rewrite-filter/utility.h
@@ -11,6 +11,7 @@ namespace Utility {
 constexpr uint8_t MIN_NUM_ARGUMENTS = 2;
 constexpr uint8_t SET_HEADER_MIN_NUM_ARGUMENTS = 4;
 constexpr uint8_t SET_PATH_MIN_NUM_ARGUMENTS = 3;
+constexpr uint8_t SET_BOOL_MIN_NUM_ARGUMENTS = 5;
 
 constexpr absl::string_view HTTP_REQUEST = "http-request";
 constexpr absl::string_view HTTP_RESPONSE = "http-response";
@@ -26,6 +27,7 @@ enum class OperationType : int {
 enum class MatchType : int {
   Exact,
   Substr,
+  Found,
   InvalidMatchType,
 };
 

--- a/header-rewrite-filter/utility.h
+++ b/header-rewrite-filter/utility.h
@@ -51,8 +51,6 @@ bool isBinaryOperator(BooleanOperatorType operator_type);
 bool evaluateExpression(std::pair<absl::string_view, bool> operand1, BooleanOperatorType operator_val, std::pair<absl::string_view, bool> operand2);
 bool evaluateExpression(bool operand1, BooleanOperatorType operator_val, std::pair<absl::string_view, bool> operand2);
 
-// bool isOperand(BooleanOperatorType operator_type);
-
 } // namespace Utility
 } // namespace HeaderRewriteFilter
 } // namespace HttpFilters


### PR DESCRIPTION
## Description
Modified `set-path` operation to preserve query string.

## Testing
```
// Write a config for the filter
// Eg. http set-bool mock_true_bool mock_string -m str mock_string
http set-bool mock_false_bool no-match -m str mock_string
http-request set-path mockpathnewversion if not mock_false_bool

// Build and run envoy
bazel build //http-filter-example:envoy
./bazel-bin/http-filter-example/envoy -c ./http-filter-example/envoy-sample-config.yaml

// Set up Docker backend to echo http headers and send a curl request to envoy
// Docker image found here: https://hub.docker.com/r/ealen/echo-server
curl localhost:8081/mockpath?queryparam=1
```

Request looks like this:
```
GET mockpathnewversion?queryparam=1 HTTP/1.1
host: localhost:8081
user-agent: curl/7.68.0
accept: */*
x-forwarded-proto: http,https
x-request-id: 44a1cdce-e520-4348-ba39-e360e2daf257
x-envoy-expected-rq-timeout-ms: 15000
```

The path has been modified.
