### PR TITLE
use iterator to parse expressions

### DIFF
--- a/header-rewrite-filter/header_rewrite.cc
+++ b/header-rewrite-filter/header_rewrite.cc
@@ -77,7 +77,7 @@ HttpHeaderRewriteFilter::HttpHeaderRewriteFilter(HttpHeaderRewriteFilterConfigSh
 
     // parse operation
     if (processor) {
-      const absl::Status status = processor->parseOperation(tokens, tokens.begin());
+      const absl::Status status = processor->parseOperation(tokens, tokens.begin() + 2);
       if (!status.ok()) {
         fail(status.message());
         setError();


### PR DESCRIPTION
This PR modifies the header processors to make use of an iterator that is passed in to each respective `parseOperation` function. As a result, each processor only receives the part of the operation that is relevant to that processor.

I verified that everything still works through the test plan outlined in past pull requests (see https://github.com/DataDog/envoy-filter-example/pull/9).