### PR TITLE
modified set path operation to preserve query string

### DIFF
--- a/header-rewrite-filter/header_processor.cc
+++ b/header-rewrite-filter/header_processor.cc
@@ -133,7 +133,7 @@ namespace HeaderRewriteFilter {
         }
 
         const bool condition_result = getCondition(); // whether the condition is true or false
-        const std::string request_path = getPath();
+        const std::string new_path = getPath();
 
         if (!condition_result) {
             return absl::OkStatus(); // do nothing because condition is false


### PR DESCRIPTION
This PR modifies the set path operation to preserve the query string and rewrite only the main path. The code was verified with the test plan from previous PRs (see #9).