### PR TITLE
modified set bool processor to store a lambda function for match types

### DIFF
--- a/header-rewrite-filter/header_processor.h
+++ b/header-rewrite-filter/header_processor.h
@@ -25,21 +25,11 @@ public:
   virtual ~SetBoolProcessor() {}
   virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start);
   virtual absl::Status executeOperation();
-  const std::string& getBoolName() const { return bool_name_; }
   const bool getResult(bool negate) const { return negate ? !result_ : result_; }
 
 private:
-  void setBoolName(absl::string_view bool_name) { bool_name_ = std::string(bool_name); }
-
-  const std::pair<std::string, std::string>& getStringsToCompare() const { return strings_to_compare_; }
-  void setStringsToCompare(std::pair<absl::string_view, absl::string_view> strings_to_compare);
-
-  Utility::MatchType getMatchType() const { return match_type_; }
-  void setMatchType(Utility::MatchType match_type) { match_type_ = match_type; }
-
-  std::string bool_name_;
-  std::pair<std::string, std::string> strings_to_compare_;
-  Utility::MatchType match_type_;
+  absl::string_view source_;
+  std::function<bool(absl::string_view)> matcher_ = [](absl::string_view str) -> bool { return false; };
   bool result_;
 };
 


### PR DESCRIPTION
## Description
Modified the `set-bool` processor interface to store a lambda function based on the type of match that is being performed. This makes it simpler to implement different match cases -- e.g. exact match, prefix match, 'exists,' etc.

## Testing
```
// Write a config for the filter
http set-bool mock_true_bool matches -m str matches
http set-bool mock_false_bool no-match -m str matches
http-request set-path mockpath if not mock_false_bool
http-request set-header x-forwarded-proto https if mock_true_bool and mock_true_bool or not mock_true_bool
http-response set-header mock_key mock_val1 mock_val2 if mock_false_bool or not mock_false_bool and mock_true_bool

// Build and run envoy
bazel build //header-rewrite-filter:envoy
./bazel-bin/header-rewrite-filter/envoy -c ./header-rewrite-filter/envoy-sample-config.yaml

// Set up Docker backend to echo http headers and send a curl request to envoy
// Docker image found here: https://hub.docker.com/r/ealen/echo-server
curl localhost:8081
```

Request looks like this:
```
GET mockpath HTTP/1.1
host: localhost:8081
user-agent: curl/7.68.0
accept: */*
x-forwarded-proto: http,https
x-request-id: 9b248ebd-d19f-4c88-ab6b-cea12942f238
x-envoy-expected-rq-timeout-ms: 15000
```

Response looks like this:
```
$ curl -v localhost:8081
*   Trying 127.0.0.1:8081...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8081 (#0)
> GET / HTTP/1.1
> Host: localhost:8081
> User-Agent: curl/7.68.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< x-envoy-upstream-service-time: 0
< mock_key: mock_val1,mock_val2
< date: Sun, 23 Jul 2023 18:41:41 GMT
< server: envoy
< transfer-encoding: chunked
< 
```
All three conditions were true, so the header rewrites were successfully performed.