### PR TITLE
use start iterator for parsing

### DIFF
--- a/header-rewrite-filter/envoy-sample-config.yaml
+++ b/header-rewrite-filter/envoy-sample-config.yaml
@@ -50,7 +50,7 @@ static_resources:
                   http set-bool another_mock_bool no-match -m str matches
                   http-request set-path mockpath if not another_mock_bool
                   http-request set-header x-forwarded-proto https if mock_bool and mock_bool or not mock_bool
-                  http-response set-header mock_key mock_val1 mock_val2 if another_mock_bool or not another_mock_bool and mock_bool
+                  http-response set-header mock_key mock_val1 mock_val2 if not another_mock_bool
           - name: envoy.filters.http.router
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/header-rewrite-filter/header_rewrite.cc
+++ b/header-rewrite-filter/header_rewrite.cc
@@ -73,7 +73,7 @@ HttpHeaderRewriteFilter::HttpHeaderRewriteFilter(HttpHeaderRewriteFilterConfigSh
        {
           SetBoolProcessorSharedPtr processor = std::make_unique<SetBoolProcessor>();
           const std::string boolName(tokens.at(2));
-          const absl::Status status = processor->parseOperation(tokens, tokens.begin());
+          const absl::Status status = processor->parseOperation(tokens, tokens.begin() + 2);
 
           if (!status.ok()) {
             fail(status.message());
@@ -97,7 +97,7 @@ HttpHeaderRewriteFilter::HttpHeaderRewriteFilter(HttpHeaderRewriteFilterConfigSh
 
     // parse operation
     if (processor) {
-      const absl::Status status = processor->parseOperation(tokens, tokens.begin());
+      const absl::Status status = processor->parseOperation(tokens, tokens.begin() + 2);
       if (!status.ok()) {
         fail(status.message());
         setError();


### PR DESCRIPTION
This PR modifies the header processors to make use of an iterator that is passed in to each respective `parseOperation` function. As a result, each processor only receives the part of the operation that is relevant to that processor.

I verified that everything still works through the test plan outlined in past pull requests (see https://github.com/DataDog/envoy-filter-example/pull/9).