### PR TITLE
implement append header operation

### DIFF
--- a/header-rewrite-filter/envoy-sample-config.yaml
+++ b/header-rewrite-filter/envoy-sample-config.yaml
@@ -50,7 +50,8 @@ static_resources:
                   http set-bool another_mock_bool no-match -m str matches
                   http-request set-path mockpath if not another_mock_bool
                   http-request set-header x-forwarded-proto https if mock_bool and mock_bool or not mock_bool
-                  http-response set-header mock_key mock_val1 mock_val2 if not another_mock_bool
+                  http-request append-header key value1 value2 value3 if not mock_bool or another_mock_bool or not another_mock_bool
+                  http-response set-header mock_key mock_val1 mock_val2 if mock_bool
           - name: envoy.filters.http.router
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/header-rewrite-filter/header_processor.h
+++ b/header-rewrite-filter/header_processor.h
@@ -81,6 +81,24 @@ private:
   std::vector<std::string> header_vals_; // header values to set
 };
 
+class AppendHeaderProcessor : public HeaderProcessor {
+public:
+  AppendHeaderProcessor() {}
+  virtual ~AppendHeaderProcessor() {}
+  virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start);
+  virtual absl::Status executeOperation(Http::RequestOrResponseHeaderMap& headers, SetBoolProcessorMapSharedPtr bool_processors);
+private:
+  // Note: the values returned by these functions must not outlive the AppendHeaderProcessor object
+  const absl::string_view getKey() const { return header_key_; }
+  const std::vector<std::string>& getVals() const { return header_vals_; }
+
+  void setKey(absl::string_view key) { header_key_ = std::string(key); }
+  void setVals(std::vector<std::string> vals) { header_vals_ = vals; }
+
+  std::string header_key_; // header key to set
+  std::vector<std::string> header_vals_; // header values to set
+};
+
 // Note: path being set here includes the query string
 class SetPathProcessor : public HeaderProcessor {
 public:

--- a/header-rewrite-filter/header_rewrite.cc
+++ b/header-rewrite-filter/header_rewrite.cc
@@ -60,6 +60,9 @@ HttpHeaderRewriteFilter::HttpHeaderRewriteFilter(HttpHeaderRewriteFilterConfigSh
       case Utility::OperationType::SetHeader:
         processor = std::make_unique<SetHeaderProcessor>();
         break;
+      case Utility::OperationType::AppendHeader:
+        processor = std::make_unique<AppendHeaderProcessor>();
+        break;
       case Utility::OperationType::SetPath:
         if (!isRequest) {
           fail("set-path can only be on request");

--- a/header-rewrite-filter/utility.cc
+++ b/header-rewrite-filter/utility.cc
@@ -7,11 +7,13 @@ namespace HeaderRewriteFilter {
 namespace Utility {
 
  OperationType StringToOperationType(absl::string_view operation) {
-    if (operation == "set-header") {
+    if (operation == OPERATION_SET_HEADER) {
         return OperationType::SetHeader;
-    } else if (operation == "set-path") {
+    } else if (operation == OPERATION_APPEND_HEADER) {
+        return OperationType::AppendHeader;
+    } else if (operation == OPERATION_SET_PATH) {
         return OperationType::SetPath;
-    } else if (operation == "set-bool") {
+    } else if (operation == OPERATION_SET_BOOL) {
         return OperationType::SetBool;
     } else {
         return OperationType::InvalidOperation;
@@ -31,11 +33,11 @@ MatchType StringToMatchType(absl::string_view match) {
 }
 
 BooleanOperatorType StringToBooleanOperatorType(absl::string_view bool_operator) {
-    if (bool_operator == "and") {
+    if (bool_operator == BOOLEAN_AND) {
         return BooleanOperatorType::And;
-    } else if (bool_operator == "or") {
+    } else if (bool_operator == BOOLEAN_OR) {
         return BooleanOperatorType::Or;
-    } else if (bool_operator == "not") {
+    } else if (bool_operator == BOOLEAN_NOT) {
         return BooleanOperatorType::Not;
     } else {
         return BooleanOperatorType::None;

--- a/header-rewrite-filter/utility.h
+++ b/header-rewrite-filter/utility.h
@@ -10,8 +10,16 @@ namespace Utility {
 
 constexpr uint8_t MIN_NUM_ARGUMENTS = 2;
 constexpr uint8_t SET_HEADER_MIN_NUM_ARGUMENTS = 4;
+constexpr uint8_t APPEND_HEADER_MIN_NUM_ARGUMENTS = 4;
 constexpr uint8_t SET_PATH_MIN_NUM_ARGUMENTS = 3;
 constexpr uint8_t SET_BOOL_MIN_NUM_ARGUMENTS = 6;
+
+constexpr absl::string_view OPERATION_SET_HEADER = "set-header";
+constexpr absl::string_view OPERATION_APPEND_HEADER = "append-header";
+constexpr absl::string_view OPERATION_SET_PATH = "set-path";
+constexpr absl::string_view OPERATION_SET_BOOL = "set-bool";
+
+constexpr absl::string_view IF_KEYWORD = "if";
 
 constexpr absl::string_view HTTP_REQUEST = "http-request";
 constexpr absl::string_view HTTP_RESPONSE = "http-response";
@@ -21,8 +29,13 @@ constexpr absl::string_view MATCH_TYPE_EXACT = "str";
 constexpr absl::string_view MATCH_TYPE_SUBSTR = "sub";
 constexpr absl::string_view MATCH_TYPE_FOUND = "found";
 
+constexpr absl::string_view BOOLEAN_AND = "and";
+constexpr absl::string_view BOOLEAN_OR = "or";
+constexpr absl::string_view BOOLEAN_NOT = "not";
+
 enum class OperationType : int {
   SetHeader,
+  AppendHeader,
   SetPath,
   SetBool,
   InvalidOperation,


### PR DESCRIPTION
This PR adds the `append-header` operation to the list of supported header rewrites.

Usage: `<http-request/http-response> append-header <header_key> <header_values>`

### Testing
```
// Write a config for the filter
http-response append-header key value1 value2 value3

// Build and run envoy
bazel build //http-filter-example:envoy
./bazel-bin/http-filter-example/envoy -c ./http-filter-example/envoy-sample-config.yaml

// Set up Docker backend to echo http headers and send a curl request to envoy
// Docker image found here: https://hub.docker.com/r/ealen/echo-server
curl localhost:8081
```

The response header has been added:
```
$ curl -v localhost:8081
*   Trying 127.0.0.1:8081...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8081 (#0)
> GET / HTTP/1.1
> Host: localhost:8081
> User-Agent: curl/7.68.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< x-envoy-upstream-service-time: 0
< key: value1,value2,value3
< date: Wed, 26 Jul 2023 18:12:43 GMT
< server: envoy
< transfer-encoding: chunked
< 
* Connection #0 to host localhost left intact
```