### PR TITLE
modified set header implementation

### DIFF
--- a/header-rewrite-filter/envoy-sample-config.yaml
+++ b/header-rewrite-filter/envoy-sample-config.yaml
@@ -49,9 +49,8 @@ static_resources:
                   http set-bool mock_bool matches -m str matches
                   http set-bool another_mock_bool no-match -m str matches
                   http-request set-path mockpath if not another_mock_bool
-                  http-request set-header x-forwarded-proto https if mock_bool and mock_bool or not mock_bool
                   http-request append-header key value1 value2 value3 if not mock_bool or another_mock_bool or not another_mock_bool
-                  http-response set-header mock_key mock_val1 mock_val2 if mock_bool
+                  http-request set-header x-forwarded-proto https if mock_bool and mock_bool or not mock_bool
           - name: envoy.filters.http.router
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/header-rewrite-filter/header_processor.h
+++ b/header-rewrite-filter/header_processor.h
@@ -71,14 +71,14 @@ public:
   virtual absl::Status executeOperation(Http::RequestOrResponseHeaderMap& headers, SetBoolProcessorMapSharedPtr bool_processors);
 private:
   // Note: the values returned by these functions must not outlive the SetHeaderProcessor object
-  const std::string& getKey() const { return header_key_; }
-  const std::vector<std::string>& getVals() const { return header_vals_; }
+  const absl::string_view getKey() const { return header_key_; }
+  const std::string getVal() const { return header_val_; }
 
   void setKey(absl::string_view key) { header_key_ = std::string(key); }
-  void setVals(std::vector<std::string> vals) { header_vals_ = vals; }
+  void setVal(absl::string_view val) { header_val_ = std::string(val); }
 
   std::string header_key_; // header key to set
-  std::vector<std::string> header_vals_; // header values to set
+  std::string header_val_; // header value to set
 };
 
 class AppendHeaderProcessor : public HeaderProcessor {


### PR DESCRIPTION
Modified `set-header` operation to set a header (and possibly overwrite an existing header) with only one value. Multiple values can be set with this operation by simply providing a config where the value to set is a comma delimited list of values.

### Testing
```
// Write a config for the filter
http set-bool mock_bool matches -m str matches
http set-bool another_mock_bool no-match -m str matches
http-request set-path mockpath if not another_mock_bool
http-request set-header mock_key mock_value if mock_bool and mock_bool or not mock_bool
http-request set-header another_mock_key mock_value1,mock_value2 if not another_mock_bool

// Build and run envoy
bazel build //header-rewrite-filter:envoy
./bazel-bin/header-rewrite-filter/envoy -c ./header-rewrite-filter/envoy-sample-config.yaml

// Set up Docker backend to echo http headers and send a curl request to envoy
// Docker image found here: https://hub.docker.com/r/ealen/echo-server
curl localhost:8081
```

The indicated headers have been added:
```
GET mockpath HTTP/1.1
host: localhost:8081
user-agent: curl/7.68.0
accept: */*
x-forwarded-proto: http
x-request-id: a010a04a-7627-4c49-b12f-15ec157ab150
mock_key: mock_value
another_mock_key: mock_value1,mock_value2
x-envoy-expected-rq-timeout-ms: 15000
```