### PR TITLE
modified set path operation to preserve query string

### DIFF
--- a/header-rewrite-filter/header_processor.cc
+++ b/header-rewrite-filter/header_processor.cc
@@ -133,7 +133,7 @@ namespace HeaderRewriteFilter {
         }
 
         const bool condition_result = getCondition(); // whether the condition is true or false
-        const std::string request_path = getPath();
+        const std::string new_path = getPath();
 
         if (!condition_result) {
             return absl::OkStatus(); // do nothing because condition is false
@@ -142,8 +142,20 @@ namespace HeaderRewriteFilter {
         // cast to RequestHeaderMap because setPath is only on request side
         Http::RequestHeaderMap* request_headers = static_cast<Http::RequestHeaderMap*>(&headers);
         
-        // set path (path being set here includes the query string)
-        request_headers->setPath(request_path); // should never return an error
+        // get path (includes query string)
+        absl::string_view path = request_headers->path();
+
+        const size_t offset = path.find_first_of("?");
+
+        if (offset == absl::string_view::npos) { // no query string present
+            request_headers->setPath(new_path); // should never return an error
+            return absl::OkStatus();
+        }
+
+        const absl::string_view query_string = path.substr(offset, path.length() - offset);
+
+        // set path, preserves query string
+        request_headers->setPath(new_path + std::string(query_string)); // should never return an error
 
         return absl::OkStatus();
     }


### PR DESCRIPTION
Made a mistake when updating the Graphite stack and fixing merge conflicts, this PR follows up #18 with the correct code.