### PR TITLE
Bug fix -- change string_view to string in order to prevent references from going out of scope

### DIFF
--- a/header-rewrite-filter/header_processor.cc
+++ b/header-rewrite-filter/header_processor.cc
@@ -166,10 +166,13 @@ namespace HeaderRewriteFilter {
 
             const Utility::MatchType match_type = Utility::StringToMatchType(*(start + 3));
 
+            std::string string_to_compare;
+
             switch (match_type) {
                 case Utility::MatchType::Exact:
+                    string_to_compare = std::string(*(start + 4));
                     source_ = *(start + 1);
-                    matcher_ = [start](absl::string_view source) { return source == *(start + 4); };
+                    matcher_ = [string_to_compare](absl::string_view source) { return (source.compare(string_to_compare) == 0); };
                     break;
                 // TODO: implement this
                 case Utility::MatchType::Substr:
@@ -235,10 +238,10 @@ namespace HeaderRewriteFilter {
                 } else if (Utility::isOperator(Utility::StringToBooleanOperatorType(*(it+1)))) {
                     return absl::InvalidArgumentError("invalid condition -- can't have an operator after 'not'");
                 }
-                operands_.push_back(std::pair<absl::string_view, bool>(*(it+1), true));
+                operands_.push_back(std::pair<std::string, bool>(*(it+1), true));
                 it += 2;
             } else {
-                operands_.push_back(std::pair<absl::string_view, bool>(*it, false));
+                operands_.push_back(std::pair<std::string, bool>(*it, false));
                 it++;
             }
         }

--- a/header-rewrite-filter/header_processor.h
+++ b/header-rewrite-filter/header_processor.h
@@ -28,8 +28,8 @@ public:
   const bool getResult(bool negate) const { return negate ? !result_ : result_; }
 
 private:
-  absl::string_view source_;
-  std::function<bool(absl::string_view)> matcher_ = [](absl::string_view str) -> bool { return false; };
+  std::string source_;
+  std::function<bool(std::string)> matcher_ = [](std::string str) -> bool { return false; };
   bool result_;
 };
 
@@ -48,7 +48,7 @@ public:
 
 private:
   std::vector<Utility::BooleanOperatorType> operators_;
-  std::vector<std::pair<absl::string_view, bool>> operands_; // operand and whether that operand is negated
+  std::vector<std::pair<std::string, bool>> operands_; // operand and whether that operand is negated
   bool condition_;
 };
 


### PR DESCRIPTION
## Bug/Issue
Debug statements that printed out `operands_.at(i).first` inside `ConditionProcessor::executeOperation` (any operand within a conditional) would print garbage values.

Debug threads explored:
- Double checked that iterators were not accessing out of bounds
- Verified values of `operands_` were being parsed from the operation expression and stored correctly in `ConditionProcessor::parseOperation`
- Suspected it was a memory issue because nothing in the code modified `operands_` between `parse` and `execute` function calls

## Solution
Changed member variables from `absl::string_view` to `std::string` and the bug went away -- turns out the `string_views` went out of scope when being passed from the HTTP filter to the Processor + stored inside the Processor.