### PR TITLE
implement multiple match cases

### DIFF
--- a/header-rewrite-filter/envoy-sample-config.yaml
+++ b/header-rewrite-filter/envoy-sample-config.yaml
@@ -46,11 +46,15 @@ static_resources:
               "@type": type.googleapis.com/envoy.extensions.filters.http.HeaderRewrite
               key: header-processing
               val: |
-                  http set-bool mock_bool matches -m str matches
-                  http set-bool another_mock_bool no-match -m str matches
-                  http-request set-path mockpath if not another_mock_bool
-                  http-request append-header key value1 value2 value3 if not mock_bool or another_mock_bool or not another_mock_bool
-                  http-request set-header x-forwarded-proto https if mock_bool and mock_bool or not mock_bool
+                  http set-bool prefix_true_bool mock_string -m beg mock
+                  http set-bool prefix_false_bool mock_string -m beg string
+                  http set-bool substring_true_bool mock_substring -m sub str
+                  http set-bool substring_false_bool mock_substring -m sub not_a_substring
+                  http-request set-path mockpath if prefix_true_bool
+                  http-request set-header mock_request_hdr_prefix mock_val if prefix_false_bool
+                  http-response set-header mock_response_hdr_prefix mock_response_val if prefix_true_bool
+                  http-request set-header mock_request_hdr_substring mock_val if substring_true_bool
+                  http-response set-header mock_response_hdr_substring mock_val if substring_false_bool
           - name: envoy.filters.http.router
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/header-rewrite-filter/header_processor.cc
+++ b/header-rewrite-filter/header_processor.cc
@@ -236,17 +236,22 @@ namespace HeaderRewriteFilter {
                 return absl::InvalidArgumentError("too many arguments for set bool");
             }
 
-            std::string string_to_compare;
+            const std::string string_to_compare = std::string(*(start + 4));
 
             switch (match_type) {
                 case Utility::MatchType::Exact:
-                    string_to_compare = std::string(*(start + 4));
-                    source_ = *(start + 1);
-                    matcher_ = [string_to_compare](std::string source) { return (source.compare(string_to_compare) == 0); };
+                    source_ = std::string(*(start + 1));
+                    matcher_ = [string_to_compare](std::string source) { return source.compare(string_to_compare) == 0; };
+                    break;
+                case Utility::MatchType::Prefix:
+                    source_ = std::string(*(start + 1));
+                    matcher_ = [string_to_compare](std::string source) { return string_to_compare.find(source.c_str(), 0, string_to_compare.size()) == 0; };
+                    break;
+                case Utility::MatchType::Substr:
+                    source_ = std::string(*(start + 1));
+                    matcher_ = [string_to_compare](std::string source) { return source.find(string_to_compare) != std::string::npos; };
                     break;
                 // TODO: implement this
-                case Utility::MatchType::Substr:
-                    break;
                 case Utility::MatchType::Found:
                     break;
                 default:

--- a/header-rewrite-filter/header_processor_test.cc
+++ b/header-rewrite-filter/header_processor_test.cc
@@ -127,11 +127,16 @@ TEST_F(ProcessorTest, SetPathProcessorTest) {
 
 TEST_F(ProcessorTest, SetBoolProcessorTest) {
     std::vector<absl::string_view> true_match_test_cases = {
-        "http set-bool mock_bool matches -m str matches"
+        "http set-bool mock_bool matches -m str matches", // exact
+        "http set-bool mock_bool matches -m beg ma", // prefix
+        "http set-bool mock_bool matches -m sub tch", // substring
     };
 
     std::vector<absl::string_view> false_match_test_cases = {
-        "http set-bool mock_bool matches -m str no-match"
+        "http set-bool mock_bool matches -m str no-match", // exact
+        "http set-bool mock_bool matches -m beg tch", // prefix
+        "http set-bool mock_bool mcatches -m sub not_a_substring" // substring
+
     };
 
     std::vector<absl::string_view> negative_test_cases = {
@@ -147,10 +152,12 @@ TEST_F(ProcessorTest, SetBoolProcessorTest) {
             {":method", "GET"}, {":path", "/"}, {":authority", "host"}};
         absl::Status status = set_bool_processor.parseOperation(tokens, (tokens.begin() + 2));
         EXPECT_TRUE(status == absl::OkStatus());
+        EXPECT_EQ(status.message(), "");
         std::tuple<absl::Status, bool> result = set_bool_processor.executeOperation(false);
         status = std::get<0>(result);
         bool bool_result = std::get<1>(result);
         EXPECT_TRUE(status == absl::OkStatus());
+        EXPECT_EQ(status.message(), "");
         EXPECT_TRUE(bool_result);
     }
 
@@ -161,10 +168,12 @@ TEST_F(ProcessorTest, SetBoolProcessorTest) {
             {":method", "GET"}, {":path", "/"}, {":authority", "host"}};
         absl::Status status = set_bool_processor.parseOperation(tokens, (tokens.begin() + 2));
         EXPECT_TRUE(status == absl::OkStatus());
+        EXPECT_EQ(status.message(), "");
         std::tuple<absl::Status, bool> result = set_bool_processor.executeOperation(false);
         status = std::get<0>(result);
         bool bool_result = std::get<1>(result);
         EXPECT_TRUE(status == absl::OkStatus());
+        EXPECT_EQ(status.message(), "");
         EXPECT_FALSE(bool_result);
     }
 

--- a/header-rewrite-filter/utility.cc
+++ b/header-rewrite-filter/utility.cc
@@ -23,6 +23,8 @@ namespace Utility {
 MatchType StringToMatchType(absl::string_view match) {
    if (match == MATCH_TYPE_EXACT) {
         return MatchType::Exact;
+    } else if (match == MATCH_TYPE_PREFIX) {
+        return MatchType::Prefix;
     } else if (match == MATCH_TYPE_SUBSTR) {
         return MatchType::Substr;
     } else if (match == MATCH_TYPE_FOUND) {
@@ -58,7 +60,7 @@ bool evaluateExpression(bool operand1, BooleanOperatorType operator_val, bool op
 }
 
 bool requiresArgument(MatchType match_type) {
-    return (match_type == MatchType::Exact || match_type == MatchType::Substr);
+    return (match_type == MatchType::Exact || match_type == MatchType::Substr || match_type == MatchType::Prefix);
 }
 
 } // namespace Utility

--- a/header-rewrite-filter/utility.h
+++ b/header-rewrite-filter/utility.h
@@ -26,6 +26,7 @@ constexpr absl::string_view HTTP_RESPONSE = "http-response";
 constexpr absl::string_view HTTP_REQUEST_RESPONSE = "http";
 
 constexpr absl::string_view MATCH_TYPE_EXACT = "str";
+constexpr absl::string_view MATCH_TYPE_PREFIX = "beg";
 constexpr absl::string_view MATCH_TYPE_SUBSTR = "sub";
 constexpr absl::string_view MATCH_TYPE_FOUND = "found";
 
@@ -43,6 +44,7 @@ enum class OperationType : int {
 
 enum class MatchType : int {
   Exact,
+  Prefix,
   Substr,
   Found,
   InvalidMatchType,


### PR DESCRIPTION
## Description
This PR implements prefix and substring match for `SetBoolProcessor`.

Syntax: `http set-bool <bool name> <source to match> -m <match type> <argument>`
Example: `http set-bool mock_bool mock_request_path -m beg mock_prefix` (`mock_bool` evaluates to false since `mock_prefix` is not a prefix of `mock_request_path`

## Testing
```
// Write a config for the filter
http set-bool prefix_true_bool mock_string -m beg mock
http set-bool prefix_false_bool mock_string -m beg string
http set-bool substring_true_bool mock_substring -m sub str
http set-bool substring_false_bool mock_substring -m sub not_a_substring
http-request set-path mockpath if prefix_true_bool
http-request set-header mock_request_hdr_prefix mock_val if prefix_false_bool
http-response set-header mock_response_hdr_prefix mock_response_val if prefix_true_bool
http-request set-header mock_request_hdr_substring mock_val if substring_true_bool
http-response set-header mock_response_hdr_substring mock_val if substring_false_bool

// Build and run envoy
bazel build //header-rewrite-filter:envoy
./bazel-bin/header-rewrite-filter/envoy -c ./header-rewrite-filter/envoy-sample-config.yaml

// Set up backend to echo http headers and send a curl request to envoy
$ while true; do printf 'HTTP/1.1 200 OK\r\n\r\n' | nc -Nl 8000; done
// Docker image found here: https://hub.docker.com/r/ealen/echo-server
$ curl localhost:8081
```

Request headers:
```
GET mockpath HTTP/1.1
host: localhost:8081
user-agent: curl/7.68.0
accept: */*
x-forwarded-proto: http
x-request-id: adf11c4a-2cd0-497c-b9f6-53e0b6a474fd
mock_request_hdr_substring: mock_val
x-envoy-expected-rq-timeout-ms: 15000
```
The mock_request_hdr_substring has been added.

Response headers:
```
*   Trying 127.0.0.1:8081...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8081 (#0)
> GET / HTTP/1.1
> Host: localhost:8081
> User-Agent: curl/7.68.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< x-envoy-upstream-service-time: 0
< mock_response_hdr_prefix: mock_response_val
< date: Mon, 31 Jul 2023 14:57:48 GMT
< server: envoy
< transfer-encoding: chunked
```
The mock_response_hdr_prefix has been added to the response.