### PR TITLE
implement dynamic values

### DIFF
--- a/header-rewrite-filter/BUILD
+++ b/header-rewrite-filter/BUILD
@@ -52,6 +52,8 @@ envoy_cc_library(
     deps = [
         ":pkg_cc_proto",
         ":header_rewrite_utils_lib",
+        "@envoy//source/common/common:utility_lib",
+        "@envoy//source/common/http:utility_lib",
         "@envoy//source/common/common:minimal_logger_lib",
         "@envoy//source/extensions/filters/http/common:pass_through_filter_lib",
     ],
@@ -63,6 +65,9 @@ envoy_cc_library(
     hdrs = ["utility.h",],
     repository = "@envoy",
     deps = [
+        "@envoy//source/common/http:status_lib",
+        "@envoy//source/common/http:utility_lib",
+        "@envoy//source/common/http:header_utility_lib",
         "@envoy//source/extensions/filters/http/common:pass_through_filter_lib",
     ],
 )

--- a/header-rewrite-filter/envoy-sample-config.yaml
+++ b/header-rewrite-filter/envoy-sample-config.yaml
@@ -46,15 +46,14 @@ static_resources:
               "@type": type.googleapis.com/envoy.extensions.filters.http.HeaderRewrite
               key: header-processing
               val: |
-                  http set-bool prefix_true_bool mock_string -m beg mock
-                  http set-bool prefix_false_bool mock_string -m beg string
-                  http set-bool substring_true_bool mock_substring -m sub str
-                  http set-bool substring_false_bool mock_substring -m sub not_a_substring
-                  http-request set-path mockpath if prefix_true_bool
-                  http-request set-header mock_request_hdr_prefix mock_val if prefix_false_bool
-                  http-response set-header mock_response_hdr_prefix mock_response_val if prefix_true_bool
-                  http-request set-header mock_request_hdr_substring mock_val if substring_true_bool
-                  http-response set-header mock_response_hdr_substring mock_val if substring_false_bool
+                  http set-bool true_bool hdr(mock_header,-1) -m str mock_val
+                  http set-bool false_bool hdr(transfer-encoding) -m sub not_chunked
+                  http set-bool another_true_bool urlp(mock_param) -m found
+                  http-request set-path mockpath
+                  http-request append-header mock_request_hdr another_mock_val if another_true_bool
+                  http-request set-header mock_header mock_val
+                  http-request set-header mock_request_hdr mock_val if true_bool
+                  http-response set-header mock_response_hdr mock_val if not false_bool
           - name: envoy.filters.http.router
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/header-rewrite-filter/header_processor.h
+++ b/header-rewrite-filter/header_processor.h
@@ -21,6 +21,25 @@ public:
   virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start) { return absl::OkStatus(); }
 };
 
+class DynamicFunctionProcessor : public Processor {
+public:
+  DynamicFunctionProcessor() {}
+  virtual ~DynamicFunctionProcessor() {}
+  virtual absl::Status parseOperation(absl::string_view function_expression);
+  std::tuple<absl::Status, std::string> executeOperation(Http::RequestOrResponseHeaderMap& headers);
+
+private:
+  std::tuple<absl::Status, std::string> getFunctionArgument(absl::string_view function_expression);
+  Utility::FunctionType getFunctionType(absl::string_view function_expression);
+  std::tuple<absl::Status, std::string> getUrlp(Http::RequestOrResponseHeaderMap& headers, absl::string_view param);
+  std::tuple<absl::Status, std::string> getHeaderValue(Http::RequestOrResponseHeaderMap& headers, absl::string_view key, int position);
+
+  Utility::FunctionType function_type_;
+  std::string function_argument_;
+};
+
+using DynamicFunctionProcessorSharedPtr = std::shared_ptr<DynamicFunctionProcessor>;
+
 class SetBoolProcessor : public Processor {
 public:
   SetBoolProcessor() {}
@@ -30,9 +49,7 @@ public:
 
 private:
   std::function<bool(std::string)> matcher_ = [](std::string str) -> bool { return false; };
-  Utility::FunctionType function_type_;
-  std::string function_argument_;
-
+  DynamicFunctionProcessorSharedPtr dynamic_function_processor_ = nullptr;
 };
 
 

--- a/header-rewrite-filter/header_processor.h
+++ b/header-rewrite-filter/header_processor.h
@@ -2,6 +2,8 @@
 
 #include "utility.h"
 
+#include "source/common/common/utility.h"
+#include "source/common/http/utility.h"
 #include "source/extensions/filters/http/common/pass_through_filter.h"
 
 #include <string>
@@ -24,11 +26,13 @@ public:
   SetBoolProcessor() {}
   virtual ~SetBoolProcessor() {}
   virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start);
-  virtual std::tuple<absl::Status, bool> executeOperation(bool negate);  // return status and bool result
+  virtual std::tuple<absl::Status, bool> executeOperation(Http::RequestOrResponseHeaderMap& headers, bool negate);  // return status and bool result
 
 private:
-  std::string source_;
   std::function<bool(std::string)> matcher_ = [](std::string str) -> bool { return false; };
+  Utility::FunctionType function_type_;
+  std::string function_argument_;
+
 };
 
 
@@ -40,7 +44,7 @@ public:
   ConditionProcessor() {}
   virtual ~ConditionProcessor() {}
   virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start);
-  virtual std::tuple<absl::Status, bool> executeOperation(SetBoolProcessorMapSharedPtr bool_processors);  // return status and condition result
+  virtual std::tuple<absl::Status, bool> executeOperation(Http::RequestOrResponseHeaderMap& headers, SetBoolProcessorMapSharedPtr bool_processors); // return status and condition result
 
 private:
   std::vector<Utility::BooleanOperatorType> operators_;
@@ -54,7 +58,7 @@ public:
   HeaderProcessor() {}
   virtual ~HeaderProcessor() {}
   virtual absl::Status executeOperation(Http::RequestOrResponseHeaderMap& headers, SetBoolProcessorMapSharedPtr bool_processors) { return absl::OkStatus(); }
-  virtual std::tuple<absl::Status, bool> evaluateCondition(SetBoolProcessorMapSharedPtr bool_processors);  // return status and condition result
+  virtual std::tuple<absl::Status, bool> evaluateCondition(Http::RequestOrResponseHeaderMap& headers, SetBoolProcessorMapSharedPtr bool_processors); // return status and condition result
   void setConditionProcessor(ConditionProcessorSharedPtr condition_processor) { condition_processor_ = condition_processor; }
   ConditionProcessorSharedPtr getConditionProcessor() { return condition_processor_; }
 

--- a/header-rewrite-filter/utility.cc
+++ b/header-rewrite-filter/utility.cc
@@ -46,6 +46,32 @@ BooleanOperatorType StringToBooleanOperatorType(absl::string_view bool_operator)
     }
 }
 
+FunctionType StringToFunctionType(absl::string_view function) {
+    if (function.compare(DYNAMIC_VALUE_HDR) == 0) {
+        return FunctionType::GetHdr;
+    } else if (function.compare(DYNAMIC_VALUE_URL_PARAM) == 0) {
+        return FunctionType::Urlp;
+    } else {
+        return FunctionType::InvalidFunctionType;
+    }
+}
+
+std::tuple<absl::Status, std::string> GetFunctionArgument(absl::string_view function_expression){
+    try {
+        auto start = function_expression.find_first_of("(");
+        auto end = function_expression.find_last_of(")");
+        std::string argument = std::string(function_expression).substr(start+1, function_expression.size()-start-2);
+        return std::make_tuple(absl::OkStatus(), argument);
+    } catch (std::exception& e) {
+        return std::make_tuple(absl::InvalidArgumentError("failed to get function argument"), "");
+    }
+}
+FunctionType GetFunctionType(absl::string_view function_expression){
+    const auto end = function_expression.find_first_of("(");
+    const auto dynamic_function = function_expression.substr(0, end);
+    return StringToFunctionType(dynamic_function);
+}
+
 bool isOperator(BooleanOperatorType operator_type) {
     return (operator_type == BooleanOperatorType::And || operator_type == BooleanOperatorType::Or || operator_type == BooleanOperatorType::Not);
 }
@@ -61,6 +87,67 @@ bool evaluateExpression(bool operand1, BooleanOperatorType operator_val, bool op
 
 bool requiresArgument(MatchType match_type) {
     return (match_type == MatchType::Exact || match_type == MatchType::Substr || match_type == MatchType::Prefix);
+}
+
+std::tuple<absl::Status, std::string> getHeaderValue(Http::RequestOrResponseHeaderMap& headers, std::vector<absl::string_view> arguments) {
+    try {
+        const Http::LowerCaseString header_key(arguments.at(0));
+        const Envoy::Http::HeaderUtility::GetAllOfHeaderAsStringResult header = Envoy::Http::HeaderUtility::getAllOfHeaderAsString(headers, header_key);
+
+        if (header.result() == absl::nullopt) { // header does not exist
+            return std::make_tuple(absl::OkStatus(), "");
+        }
+        const absl::string_view values_string_view = header.result().value();
+        const auto header_vals = StringUtil::splitToken(values_string_view, ",", false, true);
+        const auto num_header_vals = header_vals.size();
+
+        // get header value based on an optional position argument, if no position specified return the last value
+        if (arguments.size() > 2) {
+            return std::make_tuple(absl::InvalidArgumentError("invalid match syntax -- too many arguments to hdr function"), "");
+        }
+
+        int index;
+        if (arguments.size() == 1) { // no position specified
+            index = num_header_vals - 1;
+        } else { // position specified
+            index = std::stoi(std::string(arguments.at(1)));
+            if (index < 0) { // negative position specified
+                index += num_header_vals;
+            }
+        }
+
+        // validate index
+        if ((index < 0) || (index >= num_header_vals)) {
+            return std::make_tuple(absl::InvalidArgumentError("invalid match syntax -- hdr position out of bounds"), "");
+        }
+
+        // get comma-separated value of the header
+        const auto header_val = header_vals.at(index);
+        const std::string source(header_val);
+
+        return std::make_tuple(absl::OkStatus(), source);
+    } catch (std::exception& e) { // should never happen, bounds are checked above
+        return std::make_tuple(absl::InvalidArgumentError("failed to perform boolean match -- " + std::string(e.what())), "");
+    }
+}
+
+std::tuple<absl::Status, std::string> getUrlp(Http::RequestOrResponseHeaderMap& headers, std::vector<absl::string_view> arguments) {
+    try {
+        Http::RequestHeaderMap* request_headers = dynamic_cast<Http::RequestHeaderMap*>(&headers); // can fail if invalid config is provided, ie if response tries to get path
+        if (!request_headers) {
+            return std::make_tuple(absl::InvalidArgumentError("cannot call urlp function on response side"), "");
+        }
+        const auto query_parameters = Http::Utility::parseQueryString(request_headers->Path()[0].value().getStringView());
+        const auto& iter = query_parameters.find(std::string(arguments.at(0)));
+        if (iter == query_parameters.end()) { // query param doesn't exist
+            return std::make_tuple(absl::OkStatus(), "");
+        }
+        
+        const std::string source(iter->second);
+        return std::make_tuple(absl::OkStatus(), source);
+    } catch (std::exception& e) { // should never happen, bounds are checked above
+        return std::make_tuple(absl::InvalidArgumentError("failed to perform boolean match" + std::string(e.what())), "");
+    }
 }
 
 } // namespace Utility

--- a/header-rewrite-filter/utility.cc
+++ b/header-rewrite-filter/utility.cc
@@ -56,22 +56,6 @@ FunctionType StringToFunctionType(absl::string_view function) {
     }
 }
 
-std::tuple<absl::Status, std::string> GetFunctionArgument(absl::string_view function_expression){
-    try {
-        auto start = function_expression.find_first_of("(");
-        auto end = function_expression.find_last_of(")");
-        std::string argument = std::string(function_expression).substr(start+1, function_expression.size()-start-2);
-        return std::make_tuple(absl::OkStatus(), argument);
-    } catch (std::exception& e) {
-        return std::make_tuple(absl::InvalidArgumentError("failed to get function argument"), "");
-    }
-}
-FunctionType GetFunctionType(absl::string_view function_expression){
-    const auto end = function_expression.find_first_of("(");
-    const auto dynamic_function = function_expression.substr(0, end);
-    return StringToFunctionType(dynamic_function);
-}
-
 bool isOperator(BooleanOperatorType operator_type) {
     return (operator_type == BooleanOperatorType::And || operator_type == BooleanOperatorType::Or || operator_type == BooleanOperatorType::Not);
 }
@@ -87,67 +71,6 @@ bool evaluateExpression(bool operand1, BooleanOperatorType operator_val, bool op
 
 bool requiresArgument(MatchType match_type) {
     return (match_type == MatchType::Exact || match_type == MatchType::Substr || match_type == MatchType::Prefix);
-}
-
-std::tuple<absl::Status, std::string> getHeaderValue(Http::RequestOrResponseHeaderMap& headers, std::vector<absl::string_view> arguments) {
-    try {
-        const Http::LowerCaseString header_key(arguments.at(0));
-        const Envoy::Http::HeaderUtility::GetAllOfHeaderAsStringResult header = Envoy::Http::HeaderUtility::getAllOfHeaderAsString(headers, header_key);
-
-        if (header.result() == absl::nullopt) { // header does not exist
-            return std::make_tuple(absl::OkStatus(), "");
-        }
-        const absl::string_view values_string_view = header.result().value();
-        const auto header_vals = StringUtil::splitToken(values_string_view, ",", false, true);
-        const auto num_header_vals = header_vals.size();
-
-        // get header value based on an optional position argument, if no position specified return the last value
-        if (arguments.size() > 2) {
-            return std::make_tuple(absl::InvalidArgumentError("invalid match syntax -- too many arguments to hdr function"), "");
-        }
-
-        int index;
-        if (arguments.size() == 1) { // no position specified
-            index = num_header_vals - 1;
-        } else { // position specified
-            index = std::stoi(std::string(arguments.at(1)));
-            if (index < 0) { // negative position specified
-                index += num_header_vals;
-            }
-        }
-
-        // validate index
-        if ((index < 0) || (index >= num_header_vals)) {
-            return std::make_tuple(absl::InvalidArgumentError("invalid match syntax -- hdr position out of bounds"), "");
-        }
-
-        // get comma-separated value of the header
-        const auto header_val = header_vals.at(index);
-        const std::string source(header_val);
-
-        return std::make_tuple(absl::OkStatus(), source);
-    } catch (std::exception& e) { // should never happen, bounds are checked above
-        return std::make_tuple(absl::InvalidArgumentError("failed to perform boolean match -- " + std::string(e.what())), "");
-    }
-}
-
-std::tuple<absl::Status, std::string> getUrlp(Http::RequestOrResponseHeaderMap& headers, std::vector<absl::string_view> arguments) {
-    try {
-        Http::RequestHeaderMap* request_headers = dynamic_cast<Http::RequestHeaderMap*>(&headers); // can fail if invalid config is provided, ie if response tries to get path
-        if (!request_headers) {
-            return std::make_tuple(absl::InvalidArgumentError("cannot call urlp function on response side"), "");
-        }
-        const auto query_parameters = Http::Utility::parseQueryString(request_headers->Path()[0].value().getStringView());
-        const auto& iter = query_parameters.find(std::string(arguments.at(0)));
-        if (iter == query_parameters.end()) { // query param doesn't exist
-            return std::make_tuple(absl::OkStatus(), "");
-        }
-        
-        const std::string source(iter->second);
-        return std::make_tuple(absl::OkStatus(), source);
-    } catch (std::exception& e) { // should never happen, bounds are checked above
-        return std::make_tuple(absl::InvalidArgumentError("failed to perform boolean match" + std::string(e.what())), "");
-    }
 }
 
 } // namespace Utility

--- a/header-rewrite-filter/utility.h
+++ b/header-rewrite-filter/utility.h
@@ -1,6 +1,10 @@
 #pragma once
 
 #include "absl/strings/string_view.h"
+#include "absl/status/status.h"
+#include "source/extensions/filters/http/common/pass_through_filter.h"
+#include "source/common/http/header_utility.h"
+#include "source/common/http/utility.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -34,6 +38,9 @@ constexpr absl::string_view BOOLEAN_AND = "and";
 constexpr absl::string_view BOOLEAN_OR = "or";
 constexpr absl::string_view BOOLEAN_NOT = "not";
 
+constexpr absl::string_view DYNAMIC_VALUE_HDR = "hdr";
+constexpr absl::string_view DYNAMIC_VALUE_URL_PARAM = "urlp";
+
 enum class OperationType : int {
   SetHeader,
   AppendHeader,
@@ -57,13 +64,26 @@ enum class BooleanOperatorType : int {
   None,
 };
 
+enum class FunctionType : int {
+  GetHdr,
+  Urlp,
+  InvalidFunctionType
+};
+
 OperationType StringToOperationType(absl::string_view operation);
 MatchType StringToMatchType(absl::string_view match);
 BooleanOperatorType StringToBooleanOperatorType(absl::string_view bool_operator);
+FunctionType StringToFunctionType(absl::string_view function);
 
 bool isOperator(BooleanOperatorType operator_type);
 bool isBinaryOperator(BooleanOperatorType operator_type);
 bool evaluateExpression(bool operand1, BooleanOperatorType operator_val, bool operand2);
+
+std::tuple<absl::Status, std::string> GetFunctionArgument(absl::string_view function_expression);
+FunctionType GetFunctionType(absl::string_view function_expression);
+
+std::tuple<absl::Status, std::string> getHeaderValue(Http::RequestOrResponseHeaderMap& headers, std::vector<absl::string_view> arguments);
+std::tuple<absl::Status, std::string> getUrlp(Http::RequestOrResponseHeaderMap& headers, std::vector<absl::string_view> arguments);
 
 bool requiresArgument(MatchType match_type);
 

--- a/header-rewrite-filter/utility.h
+++ b/header-rewrite-filter/utility.h
@@ -79,12 +79,6 @@ bool isOperator(BooleanOperatorType operator_type);
 bool isBinaryOperator(BooleanOperatorType operator_type);
 bool evaluateExpression(bool operand1, BooleanOperatorType operator_val, bool operand2);
 
-std::tuple<absl::Status, std::string> GetFunctionArgument(absl::string_view function_expression);
-FunctionType GetFunctionType(absl::string_view function_expression);
-
-std::tuple<absl::Status, std::string> getHeaderValue(Http::RequestOrResponseHeaderMap& headers, std::vector<absl::string_view> arguments);
-std::tuple<absl::Status, std::string> getUrlp(Http::RequestOrResponseHeaderMap& headers, std::vector<absl::string_view> arguments);
-
 bool requiresArgument(MatchType match_type);
 
 } // namespace Utility


### PR DESCRIPTION
## Description
This PR modifies the `SetBoolProcessor` to set a boolean value strictly based on the result of a function call. Supported function calls are getting a specific header or the url path.

## Testing
See test setup in previous PRs (ex: #12)

Using the following config:
```
http set-bool mock_bool req.hdr(x-forwarded-proto) -m str http
http-request set-path mockpath if mock_bool or not mock_bool
```

We see that the path has been updated:
```
GET mockpath HTTP/1.1
host: localhost:8081
user-agent: curl/7.68.0
accept: */*
x-forwarded-proto: http
x-request-id: b3bec725-270d-4898-931e-84aeb9031f89
x-envoy-expected-rq-timeout-ms: 15000
```

Another example:
```
http set-bool true_bool hdr(mock_header,-1) -m str mock_val
http set-bool false_bool hdr(transfer-encoding) -m sub not_chunked
http set-bool another_true_bool urlp(mock_param) -m found
http-request set-path mockpath
http-request append-header mock_request_hdr another_mock_val if another_true_bool
http-request set-header mock_header mock_val
http-request set-header mock_request_hdr mock_val if true_bool
http-response set-header mock_response_hdr mock_val if not false_bool
```
Request side:
```
GET mockpath HTTP/1.1
host: localhost:8081
user-agent: curl/7.68.0
accept: */*
x-forwarded-proto: http
x-request-id: 4ccafdbf-a386-451f-928b-a9fdefb21cf5
mock_header: mock_val
mock_request_hdr: mock_val
x-envoy-expected-rq-timeout-ms: 15000
```

Response side:
```
$ curl -v localhost:8081
*   Trying 127.0.0.1:8081...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8081 (#0)
> GET / HTTP/1.1
> Host: localhost:8081
> User-Agent: curl/7.68.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< x-envoy-upstream-service-time: 0
< mock_response_hdr: mock_val
< date: Mon, 31 Jul 2023 22:10:01 GMT
< server: envoy
< transfer-encoding: chunked
```