### PR TITLE
unit tests for processors

### DIFF
--- a/header-rewrite-filter/header_processor.cc
+++ b/header-rewrite-filter/header_processor.cc
@@ -56,7 +56,7 @@ namespace HeaderRewriteFilter {
 
     absl::Status AppendHeaderProcessor::parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start) {
         if (operation_expression.size() < Utility::APPEND_HEADER_MIN_NUM_ARGUMENTS) {
-            return absl::InvalidArgumentError("not enough arguments for set-header");
+            return absl::InvalidArgumentError("not enough arguments for append-header");
         }
 
         // parse key and call setKey
@@ -224,6 +224,18 @@ namespace HeaderRewriteFilter {
 
             const Utility::MatchType match_type = Utility::StringToMatchType(*(start + 3));
 
+            // validate number of arguments
+            if (Utility::requiresArgument(match_type)) {
+                if (operation_expression.size() == Utility::SET_BOOL_MIN_NUM_ARGUMENTS) {
+                    return absl::InvalidArgumentError("missing argument for match type");
+                }
+                if (operation_expression.size() > (Utility::SET_BOOL_MIN_NUM_ARGUMENTS + 1)) {
+                    return absl::InvalidArgumentError("too many arguments for set bool");
+                }
+            } else if (operation_expression.size() > Utility::SET_BOOL_MIN_NUM_ARGUMENTS) { // if match type does not have an arg
+                return absl::InvalidArgumentError("too many arguments for set bool");
+            }
+
             std::string string_to_compare;
 
             switch (match_type) {
@@ -260,16 +272,19 @@ namespace HeaderRewriteFilter {
     }
 
     absl::Status ConditionProcessor::parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start) {
+        // make sure operands and operators vectors are empty
+        operands_ = {};
+        operators_ = {};
+
         Utility::BooleanOperatorType start_type;
-        try {
-            start_type = Utility::StringToBooleanOperatorType(*start);
-        } catch (std::exception& e) {
-            return absl::InvalidArgumentError("failed to parse condition -- " + std::string(e.what()));
+        if (operation_expression.size() < 1) {
+            return absl::InvalidArgumentError("empty condition provided to condition processor");
         }
+        start_type = Utility::StringToBooleanOperatorType(*start);
 
         // conditional can't start with a binary operator
         if (Utility::isBinaryOperator(start_type)) {
-            return absl::InvalidArgumentError("invalid condition -- condition must begin with '!' or an operand");
+            return absl::InvalidArgumentError("invalid condition -- condition must begin with 'not' or an operand");
         }
 
         for (auto it = start; it != operation_expression.end();) {
@@ -307,7 +322,7 @@ namespace HeaderRewriteFilter {
         }
 
         // validate number of operands and operators
-        return (operators_.size() == operands_.size() - 1) ? absl::OkStatus() : absl::InvalidArgumentError("invalid condition");
+        return (operators_.size() == (operands_.size() - 1)) ? absl::OkStatus() : absl::InvalidArgumentError("invalid condition");
     }
 
     // return status and condition result
@@ -334,7 +349,7 @@ namespace HeaderRewriteFilter {
             while (operators_it != operators_.end() && operands_it != operands_.end()) {
                 bool_processor = set_bool_processors->at(std::string(std::get<0>((*operands_it))));
 
-                const std::tuple<absl::Status, bool> bool_var_result = bool_processor->executeOperation(std::get<1>(operands_.at(0)));
+                const std::tuple<absl::Status, bool> bool_var_result = bool_processor->executeOperation(std::get<1>(*operands_it));
                 const absl::Status status = std::get<0>(bool_var_result);
                 if (status != absl::OkStatus()) {
                     return std::make_tuple(status, false);
@@ -349,7 +364,7 @@ namespace HeaderRewriteFilter {
             return std::make_tuple(absl::OkStatus(), result);
 
         } catch (std::exception& e) { // fails gracefully if a faulty map access occurs
-            return std::make_tuple(absl::InvalidArgumentError("failed to process condition" + std::string(e.what())), false);
+            return std::make_tuple(absl::InvalidArgumentError("failed to process condition -- " + std::string(e.what())), false);
         }
     }
 

--- a/header-rewrite-filter/header_processor_test.cc
+++ b/header-rewrite-filter/header_processor_test.cc
@@ -14,85 +14,255 @@ protected:
     void SetUp() override { }
 };
 
-// Note: both processors assume that the first two arguments are validated (these arguments are validated by the filter)
+using SetBoolProcessorSharedPtr = std::shared_ptr<SetBoolProcessor>;
+using SetBoolProcessorMapSharedPtr = std::shared_ptr<std::unordered_map<std::string, SetBoolProcessorSharedPtr>>;
+
+// Note: processors assume that the first two arguments are validated (these arguments are validated by the filter)
 
 TEST_F(ProcessorTest, SetHeaderProcessorTest) {
-    SetHeaderProcessor set_header_processor = SetHeaderProcessor();
+    std::vector<absl::string_view> positive_test_cases = {
+        "http-request set-header mock_header mock_value", // can set one value
+        "http-request set-header mock_header another_mock_value" // replaces already existing value
+    };
+
+    std::vector<absl::string_view> negative_test_cases = {
+        "http-response set-header mock_key mock_val1 mock_val2", // can't set multiple values
+        "http-request set-header mock_key", // missing argument
+        "http-request set-header mock_key mock_val if" // empty condition
+    };
+
+    for (const auto operation_expression : positive_test_cases) {
+        std::vector<absl::string_view> tokens = StringUtil::splitToken(operation_expression, " ", false, true);
+        SetHeaderProcessor set_header_processor = SetHeaderProcessor();
+        Http::TestRequestHeaderMapImpl headers{
+            {":method", "GET"}, {":path", "/"}, {":authority", "host"}};
+        absl::Status status = set_header_processor.parseOperation(tokens, (tokens.begin() + 2));
+        EXPECT_TRUE(status == absl::OkStatus());
+        status = set_header_processor.executeOperation(headers, nullptr);
+        EXPECT_TRUE(status == absl::OkStatus());
+        EXPECT_EQ(tokens.at(3), headers.get(Http::LowerCaseString(tokens.at(2)))[0]->value().getStringView());
+    }
+
+    for (const auto operation_expression : negative_test_cases) {
+        std::vector<absl::string_view> tokens = StringUtil::splitToken(operation_expression, " ", false, true);
+        SetHeaderProcessor set_header_processor = SetHeaderProcessor();
+        Http::TestRequestHeaderMapImpl headers{
+            {":method", "GET"}, {":path", "/"}, {":authority", "host"}};
+        absl::Status status = set_header_processor.parseOperation(tokens, (tokens.begin() + 2));
+        EXPECT_TRUE(status.code() == absl::StatusCode::kInvalidArgument);
+    }
+}
+
+TEST_F(ProcessorTest, AppendHeaderProcessorTest) {
+    AppendHeaderProcessor append_header_processor = AppendHeaderProcessor();
     Http::TestRequestHeaderMapImpl headers{
         {":method", "GET"}, {":path", "/"}, {":authority", "host"}};
 
-    // TODO: will be changed once append-header operation is added
     // can set one value
-    std::vector<absl::string_view> operation_expression({"http-request", "set-header", "mock_header", "mock_value"});
-    absl::Status status = set_header_processor.parseOperation(operation_expression);
+    std::vector<absl::string_view> operation_expression({"http-request", "append-header", "mock_header", "mock_value"});
+    absl::Status status = append_header_processor.parseOperation(operation_expression, (operation_expression.begin() + 2));
     EXPECT_TRUE(status == absl::OkStatus());
-    set_header_processor.executeOperation(headers);
+    status = append_header_processor.executeOperation(headers, nullptr);
+    EXPECT_TRUE(status == absl::OkStatus());
     EXPECT_EQ("mock_value", headers.get(Http::LowerCaseString("mock_header"))[0]->value().getStringView());
 
     // can set multiple values
-    operation_expression = {"http-response", "set-header", "mock_key", "mock_val1", "mock_val2"};
-    status = set_header_processor.parseOperation(operation_expression);
+    operation_expression = {"http-response", "append-header", "mock_key", "mock_val1", "mock_val2"};
+    status = append_header_processor.parseOperation(operation_expression, (operation_expression.begin() + 2));
     EXPECT_TRUE(status == absl::OkStatus());
-    set_header_processor.executeOperation(headers);
-    EXPECT_EQ("mock_val1", headers.get(Http::LowerCaseString("mock_key"))[0]->value().getStringView());
-    EXPECT_EQ("mock_val2", headers.get(Http::LowerCaseString("mock_key"))[1]->value().getStringView());
+    status = append_header_processor.executeOperation(headers, nullptr);
+    EXPECT_TRUE(status == absl::OkStatus());
+    EXPECT_EQ("mock_val1,mock_val2", headers.get(Http::LowerCaseString("mock_key"))[0]->value().getStringView());
 
-    // missing argument
-    operation_expression = {"http-response", "set-header", "mock_key"};
-    status = set_header_processor.parseOperation(operation_expression);
-    EXPECT_TRUE(status != absl::OkStatus());
-    EXPECT_EQ(status.message(), "not enough arguments for set-header");
+    std::vector<absl::string_view> negative_test_cases = {
+        "http-response append-header mock_key", // missing argument
+        "http-request append-header mock_key mock_val if" // empty condition
+    };
 
+    for (const auto operation_expression : negative_test_cases) {
+        std::vector<absl::string_view> tokens = StringUtil::splitToken(operation_expression, " ", false, true);
+        AppendHeaderProcessor append_header_processor = AppendHeaderProcessor();
+        Http::TestRequestHeaderMapImpl headers{
+            {":method", "GET"}, {":path", "/"}, {":authority", "host"}};
+        absl::Status status = append_header_processor.parseOperation(tokens, (tokens.begin() + 2));
+        EXPECT_TRUE(status.code() == absl::StatusCode::kInvalidArgument);
+    }
 }
 
 TEST_F(ProcessorTest, SetPathProcessorTest) {
-    SetPathProcessor set_path_processor = SetPathProcessor();
-    Http::TestRequestHeaderMapImpl headers{
-        {":method", "GET"}, {":path", "/"}, {":authority", "host"}};
+    std::vector<absl::string_view> positive_test_cases = {
+        // correctly updates path and preserves query string
+        "http-request set-path mock_path",
+        "http-request set-path new_path"
+    };
 
-    std::vector<absl::string_view> operation_expression({"http-request", "set-path", "mock_path"});
-    absl::Status status = set_path_processor.parseOperation(operation_expression);
-    EXPECT_TRUE(status == absl::OkStatus());
-    set_path_processor.executeOperation(headers);
-    EXPECT_EQ("mock_path", headers.get(Http::LowerCaseString(":path"))[0]->value().getStringView());
+    std::vector<absl::string_view> negative_test_cases = {
+        "http-response set-path", // missing argument
+        "http-request set-path mock_path extra_arg", // extra arg
+        "http-request set-path mock_path if" // empty condition
+    };
 
-    // missing argument
-    operation_expression = {"http-request", "set-path"};
-    status = set_path_processor.parseOperation(operation_expression);
-    EXPECT_TRUE(status != absl::OkStatus());
-    EXPECT_EQ(status.message(), "not enough arguments for set-path");
+    for (const auto operation_expression : positive_test_cases) {
+        std::vector<absl::string_view> tokens = StringUtil::splitToken(operation_expression, " ", false, true);
+        SetPathProcessor set_path_processor = SetPathProcessor();
+        Http::TestRequestHeaderMapImpl headers{
+            {":method", "GET"}, {":path", "/?param=1"}, {":authority", "host"}};
+        absl::Status status = set_path_processor.parseOperation(tokens, (tokens.begin() + 2));
+        EXPECT_TRUE(status == absl::OkStatus());
+        status = set_path_processor.executeOperation(headers, nullptr);
+        EXPECT_TRUE(status == absl::OkStatus());
+        std::string expected_path = std::string(tokens.at(2)) + "?param=1";
+        EXPECT_EQ(expected_path, headers.get(Http::LowerCaseString(":path"))[0]->value().getStringView());
+    }
+
+    for (const auto operation_expression : negative_test_cases) {
+        std::vector<absl::string_view> tokens = StringUtil::splitToken(operation_expression, " ", false, true);
+        SetPathProcessor set_path_processor = SetPathProcessor();
+        Http::TestRequestHeaderMapImpl headers{
+            {":method", "GET"}, {":path", "/"}, {":authority", "host"}};
+        absl::Status status = set_path_processor.parseOperation(tokens, (tokens.begin() + 2));
+        EXPECT_TRUE(status.code() == absl::StatusCode::kInvalidArgument);
+    }
 }
 
 TEST_F(ProcessorTest, SetBoolProcessorTest) {
-    SetBoolProcessor set_bool_processor = SetBoolProcessor();
+    std::vector<absl::string_view> true_match_test_cases = {
+        "http set-bool mock_bool matches -m str matches"
+    };
 
-    Http::TestRequestHeaderMapImpl headers{
-        {":method", "GET"}, {":path", "/"}, {":authority", "host"}};
-    
-    // positive exact match
-    std::vector<absl::string_view> operation_expression({"http", "set-bool", "mock_bool", "matches", "-m", "str", "matches"});
-    absl::Status status = set_bool_processor.parseOperation(operation_expression);
+    std::vector<absl::string_view> false_match_test_cases = {
+        "http set-bool mock_bool matches -m str no-match"
+    };
+
+    std::vector<absl::string_view> negative_test_cases = {
+        "http set-bool mock_bool matches -m str", // missing argument
+        "http set-bool mock_bool matches -m str arg extra_arg", // extra arg
+        "http set-bool mock_bool matches str matches", // missing -m flag
+    };
+
+    for (const auto operation_expression : true_match_test_cases) {
+        std::vector<absl::string_view> tokens = StringUtil::splitToken(operation_expression, " ", false, true);
+        SetBoolProcessor set_bool_processor = SetBoolProcessor();
+        Http::TestRequestHeaderMapImpl headers{
+            {":method", "GET"}, {":path", "/"}, {":authority", "host"}};
+        absl::Status status = set_bool_processor.parseOperation(tokens, (tokens.begin() + 2));
+        EXPECT_TRUE(status == absl::OkStatus());
+        std::tuple<absl::Status, bool> result = set_bool_processor.executeOperation(false);
+        status = std::get<0>(result);
+        bool bool_result = std::get<1>(result);
+        EXPECT_TRUE(status == absl::OkStatus());
+        EXPECT_TRUE(bool_result);
+    }
+
+    for (const auto operation_expression : false_match_test_cases) {
+        std::vector<absl::string_view> tokens = StringUtil::splitToken(operation_expression, " ", false, true);
+        SetBoolProcessor set_bool_processor = SetBoolProcessor();
+        Http::TestRequestHeaderMapImpl headers{
+            {":method", "GET"}, {":path", "/"}, {":authority", "host"}};
+        absl::Status status = set_bool_processor.parseOperation(tokens, (tokens.begin() + 2));
+        EXPECT_TRUE(status == absl::OkStatus());
+        std::tuple<absl::Status, bool> result = set_bool_processor.executeOperation(false);
+        status = std::get<0>(result);
+        bool bool_result = std::get<1>(result);
+        EXPECT_TRUE(status == absl::OkStatus());
+        EXPECT_FALSE(bool_result);
+    }
+
+    for (const auto operation_expression : negative_test_cases) {
+        std::vector<absl::string_view> tokens = StringUtil::splitToken(operation_expression, " ", false, true);
+        SetBoolProcessor set_bool_processor = SetBoolProcessor();
+        Http::TestRequestHeaderMapImpl headers{
+            {":method", "GET"}, {":path", "/"}, {":authority", "host"}};
+        absl::Status status = set_bool_processor.parseOperation(tokens, (tokens.begin() + 2));
+        EXPECT_TRUE(status.code() == absl::StatusCode::kInvalidArgument);
+    }
+}
+
+TEST_F(ProcessorTest, ConditionProcessorTest) {
+    SetBoolProcessorMapSharedPtr mock_bool_processors = std::make_shared<std::unordered_map<std::string, SetBoolProcessorSharedPtr>>();
+    SetBoolProcessorSharedPtr mock_true_bool_processor = std::make_shared<SetBoolProcessor>();
+    SetBoolProcessorSharedPtr mock_false_bool_processor = std::make_shared<SetBoolProcessor>();
+
+    // set up mock bool processors
+    std::vector<absl::string_view> operation_expression = {"http", "set-bool", "mock_true_bool", "exact_match", "-m", "str", "exact_match"};
+    absl::Status status = mock_true_bool_processor->parseOperation(operation_expression, (operation_expression.begin() + 2));
     EXPECT_TRUE(status == absl::OkStatus());
-    set_bool_processor.executeOperation(headers);
-    EXPECT_TRUE(set_bool_processor.getResult());
-
-    // negative exact match
-    operation_expression = {"http", "set-bool", "mock_bool", "no-match", "-m", "str", "match"};
-    status = set_bool_processor.parseOperation(operation_expression);
+    operation_expression = {"http", "set-bool", "mock_false_bool", "no_match", "-m", "str", "not-a-match"};
+    status = mock_false_bool_processor->parseOperation(operation_expression, (operation_expression.begin() + 2));
     EXPECT_TRUE(status == absl::OkStatus());
-    set_bool_processor.executeOperation(headers);
-    EXPECT_FALSE(set_bool_processor.getResult());
+    mock_bool_processors->insert({"mock_true_bool", mock_true_bool_processor});
+    mock_bool_processors->insert({"mock_false_bool", mock_false_bool_processor});
 
-    // invalid number of arguments
-    operation_expression = {"http", "set-bool", "mock_bool", "matches", "-m", "str"};
-    status = set_bool_processor.parseOperation(operation_expression);
-    EXPECT_EQ(status.message(), "error parsing boolean expression");
+    // verify bool map entries
+    EXPECT_EQ(mock_bool_processors->size(), 2);
+    EXPECT_NO_THROW(mock_bool_processors->at("mock_true_bool"));
+    EXPECT_NO_THROW(mock_bool_processors->at("mock_false_bool"));
 
-    // missing -m flag
-    operation_expression = {"http", "set-bool", "mock_bool", "matches", "str", "matches"};
-    status = set_bool_processor.parseOperation(operation_expression);
-    EXPECT_EQ(status.message(), "invalid match syntax");
-    EXPECT_FALSE(set_bool_processor.getResult());
+    std::vector<absl::string_view> true_condition_test_cases = {
+        "mock_true_bool",
+        "not mock_false_bool",
+        "mock_true_bool and mock_true_bool",
+        "mock_true_bool or mock_false_bool",
+        "mock_true_bool or not mock_false_bool or mock_false_bool"
+    };
+
+    std::vector<absl::string_view> false_condition_test_cases = {
+        "mock_false_bool",
+        "not mock_true_bool",
+        "mock_true_bool or mock_false_bool and mock_false_bool"
+    };
+
+    std::vector<absl::string_view> invalid_parsing_test_cases = {
+        "and mock_true_bool",
+        "mock_true_bool and or mock_true_bool",
+        "mock_true_bool not and mock_true_bool",
+        "mock_true_bool and mock_true_bool not"
+    };
+
+    std::vector<absl::string_view> invalid_execution_test_cases = {
+        "non_existent_bool"
+    };
+
+    for (const auto operation_expression : true_condition_test_cases) {
+        std::vector<absl::string_view> tokens = StringUtil::splitToken(operation_expression, " ", false, true);
+        ConditionProcessor condition_processor = ConditionProcessor();
+        absl::Status status = condition_processor.parseOperation(tokens, tokens.begin());
+        EXPECT_TRUE(status == absl::OkStatus());
+        std::tuple<absl::Status, bool> result = condition_processor.executeOperation(mock_bool_processors);
+        status = std::get<0>(result);
+        EXPECT_TRUE(status == absl::OkStatus());
+        bool bool_result = std::get<1>(result);
+        EXPECT_TRUE(bool_result);
+    }
+
+    for (const auto operation_expression : false_condition_test_cases) {
+        std::vector<absl::string_view> tokens = StringUtil::splitToken(operation_expression, " ", false, true);
+        ConditionProcessor condition_processor = ConditionProcessor();
+        absl::Status status = condition_processor.parseOperation(tokens, tokens.begin());
+        EXPECT_TRUE(status == absl::OkStatus());
+        std::tuple<absl::Status, bool> result = condition_processor.executeOperation(mock_bool_processors);
+        status = std::get<0>(result);
+        EXPECT_TRUE(status == absl::OkStatus());
+        bool bool_result = std::get<1>(result);
+        EXPECT_TRUE(!bool_result);
+    }
+
+    for (const auto operation_expression : invalid_parsing_test_cases) {
+        std::vector<absl::string_view> tokens = StringUtil::splitToken(operation_expression, " ", false, true);
+        ConditionProcessor condition_processor = ConditionProcessor();
+        absl::Status status = condition_processor.parseOperation(tokens, tokens.begin());
+        EXPECT_TRUE(status.code() == absl::StatusCode::kInvalidArgument);
+    }
+
+    for (const auto operation_expression : invalid_execution_test_cases) {
+        std::vector<absl::string_view> tokens = StringUtil::splitToken(operation_expression, " ", false, true);
+        ConditionProcessor condition_processor = ConditionProcessor();
+        absl::Status status = condition_processor.parseOperation(tokens, tokens.begin());
+        EXPECT_TRUE(status == absl::OkStatus());
+        std::tuple<absl::Status, bool> result = condition_processor.executeOperation(mock_bool_processors);
+        status = std::get<0>(result);
+        EXPECT_TRUE(status.code() == absl::StatusCode::kInvalidArgument);
+    }
 }
 
 } // namespace HeaderRewriteFilter

--- a/header-rewrite-filter/utility.cc
+++ b/header-rewrite-filter/utility.cc
@@ -57,6 +57,9 @@ bool evaluateExpression(bool operand1, BooleanOperatorType operator_val, bool op
     return operand1 || operand2;
 }
 
+bool requiresArgument(MatchType match_type) {
+    return (match_type == MatchType::Exact || match_type == MatchType::Substr);
+}
 
 } // namespace Utility
 } // namespace HeaderRewriteFilter

--- a/header-rewrite-filter/utility.h
+++ b/header-rewrite-filter/utility.h
@@ -63,6 +63,8 @@ bool isOperator(BooleanOperatorType operator_type);
 bool isBinaryOperator(BooleanOperatorType operator_type);
 bool evaluateExpression(bool operand1, BooleanOperatorType operator_val, bool operand2);
 
+bool requiresArgument(MatchType match_type);
+
 } // namespace Utility
 } // namespace HeaderRewriteFilter
 } // namespace HttpFilters


### PR DESCRIPTION
## Description
This PR modifies the existing header rewrite unit tests to reflect recent changes in the `Processor` interfaces. It also adds unit tests for `ConditionProcessor`.

## Testing
```
$ bazel test //header-rewrite-filter:header_processor_test
INFO: Analyzed target //header-rewrite-filter:header_processor_test (0 packages loaded, 0 targets configured).
INFO: Found 1 test target...
Target //header-rewrite-filter:header_processor_test up-to-date:
  bazel-bin/header-rewrite-filter/header_processor_test
INFO: Elapsed time: 0.402s, Critical Path: 0.05s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

Executed 0 out of 1 test: 1 test passes.
```