### PR TITLE
mock bool processor

### DIFF
--- a/header-rewrite-filter/envoy-sample-config.yaml
+++ b/header-rewrite-filter/envoy-sample-config.yaml
@@ -46,9 +46,9 @@ static_resources:
               "@type": type.googleapis.com/envoy.extensions.filters.http.HeaderRewrite
               key: header-processing
               val: |
-                  http set-bool mock_bool matches -m str matches
+                  http set-bool mock_bool matches -m str matche
                   http set-bool another_mock_bool no-match -m str matches
-                  http-request set-path mockpath if not another_mock_bool
+                  http-request set-path mockpath if not mock_bool and not mock_bool
                   http-request append-header key value1 value2 value3 if not mock_bool or another_mock_bool or not another_mock_bool
                   http-request set-header x-forwarded-proto https if mock_bool and mock_bool or not mock_bool
           - name: envoy.filters.http.router

--- a/header-rewrite-filter/header_processor_test.cc
+++ b/header-rewrite-filter/header_processor_test.cc
@@ -9,90 +9,269 @@ namespace Extensions {
 namespace HttpFilters {
 namespace HeaderRewriteFilter {
 
+using ::testing::Return;
+
 class ProcessorTest : public ::testing::Test {
 protected:
     void SetUp() override { }
 };
 
-// Note: both processors assume that the first two arguments are validated (these arguments are validated by the filter)
+using SetBoolProcessorSharedPtr = std::shared_ptr<SetBoolProcessor>;
+using SetBoolProcessorMapSharedPtr = std::shared_ptr<std::unordered_map<std::string, SetBoolProcessorSharedPtr>>;
+
+// Note: processors assume that the first two arguments are validated (these arguments are validated by the filter)
 
 TEST_F(ProcessorTest, SetHeaderProcessorTest) {
     SetHeaderProcessor set_header_processor = SetHeaderProcessor();
     Http::TestRequestHeaderMapImpl headers{
         {":method", "GET"}, {":path", "/"}, {":authority", "host"}};
 
-    // TODO: will be changed once append-header operation is added
     // can set one value
     std::vector<absl::string_view> operation_expression({"http-request", "set-header", "mock_header", "mock_value"});
-    absl::Status status = set_header_processor.parseOperation(operation_expression);
+    absl::Status status = set_header_processor.parseOperation(operation_expression, (operation_expression.begin() + 2));
     EXPECT_TRUE(status == absl::OkStatus());
-    set_header_processor.executeOperation(headers);
+    status = set_header_processor.executeOperation(headers, nullptr);
+    EXPECT_TRUE(status == absl::OkStatus());
     EXPECT_EQ("mock_value", headers.get(Http::LowerCaseString("mock_header"))[0]->value().getStringView());
 
-    // can set multiple values
-    operation_expression = {"http-response", "set-header", "mock_key", "mock_val1", "mock_val2"};
-    status = set_header_processor.parseOperation(operation_expression);
+    // replaces already existing value
+    operation_expression = {"http-request", "set-header", "mock_header", "another_mock_value"};
+    status = set_header_processor.parseOperation(operation_expression, (operation_expression.begin() + 2));
     EXPECT_TRUE(status == absl::OkStatus());
-    set_header_processor.executeOperation(headers);
-    EXPECT_EQ("mock_val1", headers.get(Http::LowerCaseString("mock_key"))[0]->value().getStringView());
-    EXPECT_EQ("mock_val2", headers.get(Http::LowerCaseString("mock_key"))[1]->value().getStringView());
+    status = set_header_processor.executeOperation(headers, nullptr);
+    EXPECT_TRUE(status == absl::OkStatus());
+    EXPECT_EQ("another_mock_value", headers.get(Http::LowerCaseString("mock_header"))[0]->value().getStringView());
+
+    // can't set multiple values
+    operation_expression = {"http-response", "set-header", "mock_key", "mock_val1", "mock_val2"};
+    status = set_header_processor.parseOperation(operation_expression, (operation_expression.begin() + 2));
+    EXPECT_TRUE(status != absl::OkStatus());
+    EXPECT_EQ(status.message(), "third argument to set-header must be a condition");
 
     // missing argument
     operation_expression = {"http-response", "set-header", "mock_key"};
-    status = set_header_processor.parseOperation(operation_expression);
+    status = set_header_processor.parseOperation(operation_expression, (operation_expression.begin() + 2));
     EXPECT_TRUE(status != absl::OkStatus());
     EXPECT_EQ(status.message(), "not enough arguments for set-header");
 
+    // empty condition
+    operation_expression = {"http-response", "set-header", "mock_key", "mock_val", "if"};
+    status = set_header_processor.parseOperation(operation_expression, (operation_expression.begin() + 2));
+    EXPECT_TRUE(status != absl::OkStatus());
+    EXPECT_EQ(status.message(), "empty condition provided");
+
+}
+
+TEST_F(ProcessorTest, AppendHeaderProcessorTest) {
+    AppendHeaderProcessor append_header_processor = AppendHeaderProcessor();
+    Http::TestRequestHeaderMapImpl headers{
+        {":method", "GET"}, {":path", "/"}, {":authority", "host"}};
+
+    // can set one value
+    std::vector<absl::string_view> operation_expression({"http-request", "append-header", "mock_header", "mock_value"});
+    absl::Status status = append_header_processor.parseOperation(operation_expression, (operation_expression.begin() + 2));
+    EXPECT_TRUE(status == absl::OkStatus());
+    status = append_header_processor.executeOperation(headers, nullptr);
+    EXPECT_TRUE(status == absl::OkStatus());
+    EXPECT_EQ("mock_value", headers.get(Http::LowerCaseString("mock_header"))[0]->value().getStringView());
+
+    // can set multiple values
+    operation_expression = {"http-response", "append-header", "mock_key", "mock_val1", "mock_val2"};
+    status = append_header_processor.parseOperation(operation_expression, (operation_expression.begin() + 2));
+    EXPECT_TRUE(status == absl::OkStatus());
+    status = append_header_processor.executeOperation(headers, nullptr);
+    EXPECT_TRUE(status == absl::OkStatus());
+    EXPECT_EQ("mock_val1,mock_val2", headers.get(Http::LowerCaseString("mock_key"))[0]->value().getStringView());
+
+    // missing argument
+    operation_expression = {"http-response", "append-header", "mock_key"};
+    status = append_header_processor.parseOperation(operation_expression, (operation_expression.begin() + 2));
+    EXPECT_TRUE(status != absl::OkStatus());
+    EXPECT_EQ(status.message(), "not enough arguments for append-header");
+
+    // empty condition
+    operation_expression = {"http-response", "append-header", "mock_key", "mock_val1", "mock_val2", "if"};
+    status = append_header_processor.parseOperation(operation_expression, (operation_expression.begin() + 2));
+    EXPECT_TRUE(status != absl::OkStatus());
+    EXPECT_EQ(status.message(), "empty condition provided");
 }
 
 TEST_F(ProcessorTest, SetPathProcessorTest) {
     SetPathProcessor set_path_processor = SetPathProcessor();
     Http::TestRequestHeaderMapImpl headers{
         {":method", "GET"}, {":path", "/"}, {":authority", "host"}};
+    
+    // confirm current path
+    EXPECT_EQ("/", headers.get(Http::LowerCaseString(":path"))[0]->value().getStringView());
 
-    std::vector<absl::string_view> operation_expression({"http-request", "set-path", "mock_path"});
-    absl::Status status = set_path_processor.parseOperation(operation_expression);
+    // correctly updates path
+    std::vector<absl::string_view> operation_expression({"http-request", "set-path", "mock_path?param=1"});
+    absl::Status status = set_path_processor.parseOperation(operation_expression, (operation_expression.begin() + 2));
     EXPECT_TRUE(status == absl::OkStatus());
-    set_path_processor.executeOperation(headers);
-    EXPECT_EQ("mock_path", headers.get(Http::LowerCaseString(":path"))[0]->value().getStringView());
+    status = set_path_processor.executeOperation(headers, nullptr);
+    EXPECT_TRUE(status == absl::OkStatus());
+    EXPECT_EQ("mock_path?param=1", headers.get(Http::LowerCaseString(":path"))[0]->value().getStringView());
+
+    // preserves query string
+    operation_expression = {"http-request", "set-path", "new_path"};
+    status = set_path_processor.parseOperation(operation_expression, (operation_expression.begin() + 2));
+    EXPECT_TRUE(status == absl::OkStatus());
+    status = set_path_processor.executeOperation(headers, nullptr);
+    EXPECT_TRUE(status == absl::OkStatus());
+    EXPECT_EQ("new_path?param=1", headers.get(Http::LowerCaseString(":path"))[0]->value().getStringView());
 
     // missing argument
     operation_expression = {"http-request", "set-path"};
-    status = set_path_processor.parseOperation(operation_expression);
+    status = set_path_processor.parseOperation(operation_expression, (operation_expression.begin() + 2));
     EXPECT_TRUE(status != absl::OkStatus());
     EXPECT_EQ(status.message(), "not enough arguments for set-path");
+
+    // empty condition
+    operation_expression = {"http-response", "set-path", "mock_path", "if"};
+    status = set_path_processor.parseOperation(operation_expression, (operation_expression.begin() + 2));
+    EXPECT_TRUE(status != absl::OkStatus());
+    EXPECT_EQ(status.message(), "empty condition provided");
 }
 
 TEST_F(ProcessorTest, SetBoolProcessorTest) {
     SetBoolProcessor set_bool_processor = SetBoolProcessor();
 
+    std::vector<absl::string_view> operation_expression;
+    std::tuple<absl::Status, bool> result;
+    absl::Status status;
+    bool bool_result;
+
     Http::TestRequestHeaderMapImpl headers{
         {":method", "GET"}, {":path", "/"}, {":authority", "host"}};
     
     // positive exact match
-    std::vector<absl::string_view> operation_expression({"http", "set-bool", "mock_bool", "matches", "-m", "str", "matches"});
-    absl::Status status = set_bool_processor.parseOperation(operation_expression);
+    operation_expression = {"http", "set-bool", "mock_bool", "matches", "-m", "str", "matches"};
+    status = set_bool_processor.parseOperation(operation_expression, (operation_expression.begin() + 2));
     EXPECT_TRUE(status == absl::OkStatus());
-    set_bool_processor.executeOperation(headers);
-    EXPECT_TRUE(set_bool_processor.getResult());
+    result = set_bool_processor.executeOperation(false);
+    status = std::get<0>(result);
+    bool_result = std::get<1>(result);
+    EXPECT_TRUE(status == absl::OkStatus());
+    EXPECT_TRUE(bool_result);
 
     // negative exact match
     operation_expression = {"http", "set-bool", "mock_bool", "no-match", "-m", "str", "match"};
-    status = set_bool_processor.parseOperation(operation_expression);
+    status = set_bool_processor.parseOperation(operation_expression, (operation_expression.begin() + 2));
     EXPECT_TRUE(status == absl::OkStatus());
-    set_bool_processor.executeOperation(headers);
-    EXPECT_FALSE(set_bool_processor.getResult());
+    result = set_bool_processor.executeOperation(false);
+    status = std::get<0>(result);
+    bool_result = std::get<1>(result);
+    EXPECT_TRUE(status == absl::OkStatus());
+    EXPECT_FALSE(bool_result);
 
-    // invalid number of arguments
+    // too few arguments for exact match
     operation_expression = {"http", "set-bool", "mock_bool", "matches", "-m", "str"};
-    status = set_bool_processor.parseOperation(operation_expression);
-    EXPECT_EQ(status.message(), "error parsing boolean expression");
+    status = set_bool_processor.parseOperation(operation_expression, (operation_expression.begin() + 2));
+    EXPECT_TRUE(status != absl::OkStatus());
+    EXPECT_EQ(status.message(), "missing argument for match type");
+
+    // too many arguments for exact match
+    operation_expression = {"http", "set-bool", "mock_bool", "matches", "-m", "str", "arg", "extra_arg"};
+    status = set_bool_processor.parseOperation(operation_expression, (operation_expression.begin() + 2));
+    EXPECT_TRUE(status != absl::OkStatus());
+    EXPECT_EQ(status.message(), "too many arguments for set bool");
 
     // missing -m flag
     operation_expression = {"http", "set-bool", "mock_bool", "matches", "str", "matches"};
-    status = set_bool_processor.parseOperation(operation_expression);
+    status = set_bool_processor.parseOperation(operation_expression, (operation_expression.begin() + 2));
+    EXPECT_TRUE(status != absl::OkStatus());
     EXPECT_EQ(status.message(), "invalid match syntax");
-    EXPECT_FALSE(set_bool_processor.getResult());
+}
+
+TEST_F(ProcessorTest, ConditionProcessorTest) {
+    ConditionProcessor condition_processor = ConditionProcessor();
+    SetBoolProcessorMapSharedPtr mock_bool_processors = std::make_shared<std::unordered_map<std::string, SetBoolProcessorSharedPtr>>();
+    SetBoolProcessorSharedPtr mock_true_bool_processor = std::make_shared<SetBoolProcessor>();
+    SetBoolProcessorSharedPtr mock_false_bool_processor = std::make_shared<SetBoolProcessor>();
+
+    std::vector<absl::string_view> operation_expression;
+    std::tuple<absl::Status, bool> result;
+    absl::Status status;
+    bool bool_result;
+
+    // set up mock bool processors
+    operation_expression = {"http", "set-bool", "mock_true_bool", "exact_match", "-m", "str", "exact_match"};
+    status = mock_true_bool_processor->parseOperation(operation_expression, (operation_expression.begin() + 2));
+    EXPECT_TRUE(status == absl::OkStatus());
+    operation_expression = {"http", "set-bool", "mock_false_bool", "no_match", "-m", "str", "not-a-match"};
+    status = mock_false_bool_processor->parseOperation(operation_expression, (operation_expression.begin() + 2));
+    EXPECT_TRUE(status == absl::OkStatus());
+    mock_bool_processors->insert({"mock_true_bool", mock_true_bool_processor});
+    mock_bool_processors->insert({"mock_false_bool", mock_false_bool_processor});
+
+    // empty condition provided
+    operation_expression = {};
+    status = condition_processor.parseOperation(operation_expression, operation_expression.begin());
+    EXPECT_TRUE(status != absl::OkStatus());
+    EXPECT_EQ(status.message(), "empty condition provided to condition processor");
+
+    // single true condition
+    operation_expression = {"mock_true_bool"};
+    status = condition_processor.parseOperation(operation_expression, operation_expression.begin());
+    EXPECT_TRUE(status == absl::OkStatus());
+    result = condition_processor.executeOperation(mock_bool_processors);
+    status = std::get<0>(result);
+    EXPECT_TRUE(status == absl::OkStatus());
+    bool_result = std::get<1>(result);
+    EXPECT_TRUE(bool_result);
+
+    // single false condition
+    operation_expression = {"mock_false_bool"};
+    status = condition_processor.parseOperation(operation_expression, operation_expression.begin());
+    EXPECT_TRUE(status == absl::OkStatus());
+    result = condition_processor.executeOperation(mock_bool_processors);
+    status = std::get<0>(result);
+    EXPECT_TRUE(status == absl::OkStatus());
+    bool_result = std::get<1>(result);
+    EXPECT_TRUE(!bool_result);
+
+    EXPECT_EQ(mock_bool_processors->size(), 2);
+    EXPECT_NO_THROW(mock_bool_processors->at("mock_true_bool"));
+    EXPECT_NO_THROW(mock_bool_processors->at("mock_false_bool"));
+
+    // NOT
+    operation_expression = {"not mock_true_bool"};
+    status = condition_processor.parseOperation(operation_expression, operation_expression.begin());
+    EXPECT_TRUE(status == absl::OkStatus());
+    result = condition_processor.executeOperation(mock_bool_processors);
+    status = std::get<0>(result);
+    EXPECT_TRUE(status == absl::OkStatus());
+    bool_result = std::get<1>(result);
+    EXPECT_TRUE(!bool_result);
+
+    operation_expression = {"not mock_false_bool"};
+    status = condition_processor.parseOperation(operation_expression, operation_expression.begin());
+    EXPECT_TRUE(status == absl::OkStatus());
+    result = condition_processor.executeOperation(mock_bool_processors);
+    status = std::get<0>(result);
+    EXPECT_TRUE(status == absl::OkStatus());
+    bool_result = std::get<1>(result);
+    EXPECT_TRUE(bool_result);
+
+    // AND
+    operation_expression = {"mock_true_bool and mock_true_bool"};
+    status = condition_processor.parseOperation(operation_expression, operation_expression.begin());
+    EXPECT_TRUE(status == absl::OkStatus());
+    result = condition_processor.executeOperation(mock_bool_processors);
+    status = std::get<0>(result);
+    EXPECT_TRUE(status == absl::OkStatus());
+    bool_result = std::get<1>(result);
+    EXPECT_TRUE(bool_result);
+
+    // OR
+    operation_expression = {"mock_true_bool or mock_false_bool"};
+    status = condition_processor.parseOperation(operation_expression, operation_expression.begin());
+    EXPECT_TRUE(status == absl::OkStatus());
+    result = condition_processor.executeOperation(mock_bool_processors);
+    status = std::get<0>(result);
+    EXPECT_TRUE(status == absl::OkStatus());
+    bool_result = std::get<1>(result);
+    EXPECT_TRUE(bool_result);
 }
 
 } // namespace HeaderRewriteFilter

--- a/header-rewrite-filter/utility.cc
+++ b/header-rewrite-filter/utility.cc
@@ -57,6 +57,9 @@ bool evaluateExpression(bool operand1, BooleanOperatorType operator_val, bool op
     return operand1 || operand2;
 }
 
+bool requiresArgument(MatchType match_type) {
+    return (match_type == MatchType::Exact || match_type == MatchType::Substr);
+}
 
 } // namespace Utility
 } // namespace HeaderRewriteFilter

--- a/header-rewrite-filter/utility.h
+++ b/header-rewrite-filter/utility.h
@@ -63,6 +63,8 @@ bool isOperator(BooleanOperatorType operator_type);
 bool isBinaryOperator(BooleanOperatorType operator_type);
 bool evaluateExpression(bool operand1, BooleanOperatorType operator_val, bool operand2);
 
+bool requiresArgument(MatchType match_type);
+
 } // namespace Utility
 } // namespace HeaderRewriteFilter
 } // namespace HttpFilters


### PR DESCRIPTION
This PR attempts to mock the functionality of the `SetBoolProcessor`. I am currently getting the following build error:
```
header-rewrite-filter/header_processor_test.cc:223:51: error: cannot convert 'shared_ptr<unordered_map<[...],shared_ptr<Envoy::Extensions::HttpFilters::HeaderRewriteFilter::MockSetBoolProcessor>>>' 
to 'shared_ptr<unordered_map<[...],shared_ptr<Envoy::Extensions::HttpFilters::HeaderRewriteFilter::SetBoolProcessor>>>'
```