### PR TITLE
make bools request/response specific

### DIFF
--- a/header-rewrite-filter/envoy-sample-config.yaml
+++ b/header-rewrite-filter/envoy-sample-config.yaml
@@ -46,9 +46,9 @@ static_resources:
               "@type": type.googleapis.com/envoy.extensions.filters.http.HeaderRewrite
               key: header-processing
               val: |
-                  http set-bool true_bool hdr(mock_header,-1) -m str mock_val
-                  http set-bool false_bool hdr(transfer-encoding) -m sub not_chunked
-                  http set-bool another_true_bool urlp(mock_param) -m found
+                  http-request set-bool true_bool hdr(mock_header,-1) -m str mock_val
+                  http-response set-bool false_bool hdr(transfer-encoding) -m sub not_chunked
+                  http-request set-bool another_true_bool urlp(mock_param) -m found
                   http-request set-path mockpath
                   http-request append-header mock_request_hdr another_mock_val if another_true_bool
                   http-request set-header mock_header mock_val

--- a/header-rewrite-filter/header_processor.h
+++ b/header-rewrite-filter/header_processor.h
@@ -25,7 +25,7 @@ class DynamicFunctionProcessor : public Processor {
 public:
   DynamicFunctionProcessor() {}
   virtual ~DynamicFunctionProcessor() {}
-  virtual absl::Status parseOperation(absl::string_view function_expression);
+  virtual absl::Status parseOperation(absl::string_view function_expression, const bool isRequest);
   std::tuple<absl::Status, std::string> executeOperation(Http::RequestOrResponseHeaderMap& headers);
 
 private:

--- a/header-rewrite-filter/header_processor_test.cc
+++ b/header-rewrite-filter/header_processor_test.cc
@@ -127,31 +127,32 @@ TEST_F(ProcessorTest, SetPathProcessorTest) {
 
 TEST_F(ProcessorTest, SetBoolProcessorTest) {
     std::vector<absl::string_view> true_match_test_cases = {
-        "http set-bool mock_bool hdr(mock_header1) -m str mock_value3", // exact, hdr 1 arg
-        "http set-bool mock_bool hdr(mock_header1,-1) -m str mock_value3", // exact, hdr 2 arg
-        "http set-bool mock_bool hdr(mock_header1,0) -m str mock_value1", // exact, hdr 2 arg
-        "http set-bool mock_bool hdr(mock_header1,-3) -m str mock_value1", // exact, hdr 2 arg
-        "http set-bool mock_bool hdr(mock_header2) -m beg mo", // prefix
-        "http set-bool mock_bool urlp(param1) -m beg so", // prefix, urlp
-        "http set-bool mock_bool hdr(mock_header2) -m sub lue", // substring
-        "http set-bool mock_bool hdr(mock_header2) -m found", // found, hdr
-        "http set-bool mock_bool urlp(param2) -m found" // found, urlp
+        "http-request set-bool mock_bool hdr(mock_header1) -m str mock_value3", // exact, hdr 1 arg
+        "http-request set-bool mock_bool hdr(mock_header1,-1) -m str mock_value3", // exact, hdr 2 arg
+        "http-request set-bool mock_bool hdr(mock_header1,0) -m str mock_value1", // exact, hdr 2 arg
+        "http-request set-bool mock_bool hdr(mock_header1,-3) -m str mock_value1", // exact, hdr 2 arg
+        "http-request set-bool mock_bool hdr(mock_header2) -m beg mo", // prefix
+        "http-request set-bool mock_bool urlp(param1) -m beg so", // prefix, urlp
+        "http-request set-bool mock_bool hdr(mock_header2) -m sub lue", // substring
+        "http-request set-bool mock_bool hdr(mock_header2) -m found", // found, hdr
+        "http-request set-bool mock_bool urlp(param2) -m found" // found, urlp
     };
 
     std::vector<absl::string_view> false_match_test_cases = {
-        "http set-bool mock_bool hdr(mock_header2) -m str no-match", // exact
-        "http set-bool mock_bool hdr(mock_header1) -m beg tch", // prefix
-        "http set-bool mock_bool hdr(mock_header2) -m sub not_a_substring", // substring
-        "http set-bool mock_bool hdr(unknown_header) -m found" // found
+        "http-request set-bool mock_bool hdr(mock_header2) -m str no-match", // exact
+        "http-request set-bool mock_bool hdr(mock_header1) -m beg tch", // prefix
+        "http-request set-bool mock_bool hdr(mock_header2) -m sub not_a_substring", // substring
+        "http-request set-bool mock_bool hdr(unknown_header) -m found" // found
     };
 
     std::vector<absl::string_view> negative_test_cases = {
-        "http set-bool mock_bool hdr(mock_header1) -m str", // missing argument
-        "http set-bool mock_bool hdr(mock_header1) -m", // missing argument
-        "http set-bool mock_bool urlp(param1) -m str arg extra_arg", // extra arg
-        "http set-bool mock_bool urlp(param1) -m found extra_arg", // extra arg
-        "http set-bool mock_bool urlp(param2) str matches", // missing -m flag
-        "http set-bool mock_bool urlp(param2 -m found)" // invalid syntax
+        "http-request set-bool mock_bool hdr(mock_header1) -m str", // missing argument
+        "http-request set-bool mock_bool hdr(mock_header1) -m", // missing argument
+        "http-response set-bool mock_bool urlp(param1) -m beg so", // urlp on response side
+        "http-request set-bool mock_bool urlp(param1) -m str arg extra_arg", // extra arg
+        "http-request set-bool mock_bool urlp(param1) -m found extra_arg", // extra arg
+        "http-request set-bool mock_bool urlp(param2) str matches", // missing -m flag
+        "http-request set-bool mock_bool urlp(param2 -m found)" // invalid syntax
     };
 
     for (const auto operation_expression : true_match_test_cases) {

--- a/header-rewrite-filter/header_rewrite.h
+++ b/header-rewrite-filter/header_rewrite.h
@@ -51,7 +51,8 @@ private:
   std::vector<HeaderProcessorUniquePtr> response_header_processors_;
 
   // set_bool processors
-  SetBoolProcessorMapSharedPtr set_bool_processors_;
+  SetBoolProcessorMapSharedPtr request_set_bool_processors_;
+  SetBoolProcessorMapSharedPtr response_set_bool_processors_;
 
   const Http::LowerCaseString headerKey() const;
   const std::string headerValue() const;

--- a/header-rewrite-filter/utility.h
+++ b/header-rewrite-filter/utility.h
@@ -27,7 +27,6 @@ constexpr absl::string_view IF_KEYWORD = "if";
 
 constexpr absl::string_view HTTP_REQUEST = "http-request";
 constexpr absl::string_view HTTP_RESPONSE = "http-response";
-constexpr absl::string_view HTTP_REQUEST_RESPONSE = "http";
 
 constexpr absl::string_view MATCH_TYPE_EXACT = "str";
 constexpr absl::string_view MATCH_TYPE_PREFIX = "beg";


### PR DESCRIPTION
## Description
This PR modifies the bool processor framework to use 2 separate bool maps -- one for the request side and one for the response side. A bool will now only be valid on one path rather than silently failing if called on the wrong path, which disambiguates where that bool is getting its dynamic value from.

## Testing
Tested this PR by running the associated unit tests.
```
$ bazel test --test_output=all //header-rewrite-filter:header_processor_test
==================== Test output for //header-rewrite-filter:header_processor_test:
[==========] Running 5 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 5 tests from ProcessorTest
[ RUN      ] ProcessorTest.SetHeaderProcessorTest
[       OK ] ProcessorTest.SetHeaderProcessorTest (2 ms)
[ RUN      ] ProcessorTest.AppendHeaderProcessorTest
[       OK ] ProcessorTest.AppendHeaderProcessorTest (0 ms)
[ RUN      ] ProcessorTest.SetPathProcessorTest
[       OK ] ProcessorTest.SetPathProcessorTest (1 ms)
[ RUN      ] ProcessorTest.SetBoolProcessorTest
[       OK ] ProcessorTest.SetBoolProcessorTest (1 ms)
[ RUN      ] ProcessorTest.ConditionProcessorTest
[       OK ] ProcessorTest.ConditionProcessorTest (1 ms)
[----------] 5 tests from ProcessorTest (5 ms total)

[----------] Global test environment tear-down
[==========] 5 tests from 1 test suite ran. (5 ms total)
[  PASSED  ] 5 tests.
================================================================================
Target //header-rewrite-filter:header_processor_test up-to-date:
  bazel-bin/header-rewrite-filter/header_processor_test
INFO: Elapsed time: 80.233s, Critical Path: 79.81s
INFO: 4 processes: 1 internal, 3 linux-sandbox.
INFO: Build completed successfully, 4 total actions

Executed 1 out of 1 test: 1 test passes.
```