### PR TITLE
implemented dynamic metadata

### DIFF
--- a/header-rewrite-filter/envoy-sample-config.yaml
+++ b/header-rewrite-filter/envoy-sample-config.yaml
@@ -46,14 +46,16 @@ static_resources:
               "@type": type.googleapis.com/envoy.extensions.filters.http.HeaderRewrite
               key: header-processing
               val: |
-                  http-request set-bool true_bool hdr(mock_header,-1) -m str mock_val
-                  http-response set-bool false_bool hdr(transfer-encoding) -m sub not_chunked
-                  http-request set-bool another_true_bool urlp(mock_param) -m found
+                  http-request set-bool true_bool %[hdr(mock_header,-1)] -m str mock_val
+                  http-response set-bool false_bool %[hdr(transfer-encoding)] -m sub not_chunked
+                  http-request set-bool another_true_bool %[urlp(mock_param)] -m found
                   http-request set-path mockpath
                   http-request append-header mock_request_hdr another_mock_val if another_true_bool
                   http-request set-header mock_header mock_val
                   http-request set-header mock_request_hdr mock_val if true_bool
                   http-response set-header mock_response_hdr mock_val if not false_bool
+                  http-request set-metadata mock_key %[hdr(mock_header,-1)] if true_bool
+                  http-request set-metadata mock_key %[urlp(param1)]
           - name: envoy.filters.http.router
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/header-rewrite-filter/header_processor.h
+++ b/header-rewrite-filter/header_processor.h
@@ -14,19 +14,27 @@ namespace Extensions {
 namespace HttpFilters {
 namespace HeaderRewriteFilter {
 
+class SetBoolProcessor;
+using SetBoolProcessorSharedPtr = std::shared_ptr<SetBoolProcessor>;
+using SetBoolProcessorMapSharedPtr = std::shared_ptr<std::unordered_map<std::string, SetBoolProcessorSharedPtr>>;
+
 class Processor {
 public:
-  Processor() {}
+  Processor(SetBoolProcessorMapSharedPtr bool_processors, bool isRequest) : bool_processors_(bool_processors), is_request_(isRequest)  { }
   virtual ~Processor() {}
   virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start) { return absl::OkStatus(); }
+
+protected:
+  SetBoolProcessorMapSharedPtr bool_processors_;
+  bool is_request_; // header rewrite filter has already verified that the operation is always either http-request or http-response
 };
 
 class DynamicFunctionProcessor : public Processor {
 public:
-  DynamicFunctionProcessor() {}
+  DynamicFunctionProcessor(SetBoolProcessorMapSharedPtr bool_processors, bool isRequest) : Processor(bool_processors, isRequest) {}
   virtual ~DynamicFunctionProcessor() {}
-  virtual absl::Status parseOperation(absl::string_view function_expression, const bool isRequest);
-  std::tuple<absl::Status, std::string> executeOperation(Http::RequestOrResponseHeaderMap& headers);
+  virtual absl::Status parseOperation(absl::string_view function_expression);
+  std::tuple<absl::Status, std::string> executeOperation(Http::RequestOrResponseHeaderMap& headers, Http::StreamFilterCallbacks* callbacks);
 
 private:
   std::tuple<absl::Status, std::string> getFunctionArgument(absl::string_view function_expression);
@@ -42,26 +50,22 @@ using DynamicFunctionProcessorSharedPtr = std::shared_ptr<DynamicFunctionProcess
 
 class SetBoolProcessor : public Processor {
 public:
-  SetBoolProcessor() {}
+  SetBoolProcessor(SetBoolProcessorMapSharedPtr bool_processors, bool isRequest) : Processor(bool_processors, isRequest) {}
   virtual ~SetBoolProcessor() {}
   virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start);
-  virtual std::tuple<absl::Status, bool> executeOperation(Http::RequestOrResponseHeaderMap& headers, bool negate);  // return status and bool result
+  virtual std::tuple<absl::Status, bool> executeOperation(Http::RequestOrResponseHeaderMap& headers, Http::StreamFilterCallbacks* callbacks, bool negate);  // return status and bool result
 
 private:
   std::function<bool(std::string)> matcher_ = [](std::string str) -> bool { return false; };
   DynamicFunctionProcessorSharedPtr dynamic_function_processor_ = nullptr;
 };
 
-
-using SetBoolProcessorSharedPtr = std::shared_ptr<SetBoolProcessor>;
-using SetBoolProcessorMapSharedPtr = std::shared_ptr<std::unordered_map<std::string, SetBoolProcessorSharedPtr>>;
-
 class ConditionProcessor : public Processor {
 public:
-  ConditionProcessor() {}
+  ConditionProcessor(SetBoolProcessorMapSharedPtr bool_processors, bool isRequest) : Processor(bool_processors, isRequest) {}
   virtual ~ConditionProcessor() {}
   virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start);
-  virtual std::tuple<absl::Status, bool> executeOperation(Http::RequestOrResponseHeaderMap& headers, SetBoolProcessorMapSharedPtr bool_processors); // return status and condition result
+  virtual std::tuple<absl::Status, bool> executeOperation(Http::RequestOrResponseHeaderMap& headers, Http::StreamFilterCallbacks* callbacks); // return status and condition result
 
 private:
   std::vector<Utility::BooleanOperatorType> operators_;
@@ -72,10 +76,10 @@ using ConditionProcessorSharedPtr = std::shared_ptr<ConditionProcessor>;
 
 class HeaderProcessor : public Processor {
 public:
-  HeaderProcessor() {}
+  HeaderProcessor(SetBoolProcessorMapSharedPtr bool_processors, bool isRequest) : Processor(bool_processors, isRequest) {}
   virtual ~HeaderProcessor() {}
-  virtual absl::Status executeOperation(Http::RequestOrResponseHeaderMap& headers, SetBoolProcessorMapSharedPtr bool_processors) { return absl::OkStatus(); }
-  virtual std::tuple<absl::Status, bool> evaluateCondition(Http::RequestOrResponseHeaderMap& headers, SetBoolProcessorMapSharedPtr bool_processors); // return status and condition result
+  virtual absl::Status executeOperation(Http::RequestOrResponseHeaderMap& headers, Http::StreamFilterCallbacks* callbacks) { return absl::OkStatus(); }
+  virtual std::tuple<absl::Status, bool> evaluateCondition(Http::RequestOrResponseHeaderMap& headers, Http::StreamFilterCallbacks* callbacks); // return status and condition result
   void setConditionProcessor(ConditionProcessorSharedPtr condition_processor) { condition_processor_ = condition_processor; }
   ConditionProcessorSharedPtr getConditionProcessor() { return condition_processor_; }
 
@@ -86,10 +90,10 @@ protected:
 
 class SetHeaderProcessor : public HeaderProcessor {
 public:
-  SetHeaderProcessor() {}
+  SetHeaderProcessor(SetBoolProcessorMapSharedPtr bool_processors, bool isRequest) : HeaderProcessor(bool_processors, isRequest) {}
   virtual ~SetHeaderProcessor() {}
   virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start);
-  virtual absl::Status executeOperation(Http::RequestOrResponseHeaderMap& headers, SetBoolProcessorMapSharedPtr bool_processors);
+  virtual absl::Status executeOperation(Http::RequestOrResponseHeaderMap& headers, Http::StreamFilterCallbacks* callbacks);
 private:
   // Note: the values returned by these functions must not outlive the SetHeaderProcessor object
   const absl::string_view getKey() const { return header_key_; }
@@ -104,10 +108,10 @@ private:
 
 class AppendHeaderProcessor : public HeaderProcessor {
 public:
-  AppendHeaderProcessor() {}
+  AppendHeaderProcessor(SetBoolProcessorMapSharedPtr bool_processors, bool isRequest) : HeaderProcessor(bool_processors, isRequest) {}
   virtual ~AppendHeaderProcessor() {}
   virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start);
-  virtual absl::Status executeOperation(Http::RequestOrResponseHeaderMap& headers, SetBoolProcessorMapSharedPtr bool_processors);
+  virtual absl::Status executeOperation(Http::RequestOrResponseHeaderMap& headers, Http::StreamFilterCallbacks* callbacks);
 private:
   // Note: the values returned by these functions must not outlive the AppendHeaderProcessor object
   const absl::string_view getKey() const { return header_key_; }
@@ -123,16 +127,30 @@ private:
 // Note: path being set here includes the query string
 class SetPathProcessor : public HeaderProcessor {
 public:
-  SetPathProcessor() {}
+  SetPathProcessor(SetBoolProcessorMapSharedPtr bool_processors, bool isRequest) : HeaderProcessor(bool_processors, isRequest) {}
   virtual ~SetPathProcessor() {}
   virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start);
-  virtual absl::Status executeOperation(Http::RequestOrResponseHeaderMap& headers, SetBoolProcessorMapSharedPtr bool_processors);
+  virtual absl::Status executeOperation(Http::RequestOrResponseHeaderMap& headers, Http::StreamFilterCallbacks* callbacks);
 
 private:
+  // Note: the values returned by these functions must not outlive the SetHeaderProcessor object
   const std::string& getPath() const { return request_path_; }
   void setPath(absl::string_view path) { request_path_ = std::string(path); }
 
   std::string request_path_; // path to set
+};
+
+class SetDynamicMetadataProcessor : public HeaderProcessor {
+public:
+  SetDynamicMetadataProcessor(SetBoolProcessorMapSharedPtr bool_processors, bool isRequest) : HeaderProcessor(bool_processors, isRequest) {}
+  virtual ~SetDynamicMetadataProcessor() {}
+  virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start);
+  virtual absl::Status executeOperation(Http::RequestOrResponseHeaderMap& headers, Http::StreamFilterCallbacks* callbacks);
+
+private:
+  // Note: the values returned by these functions must not outlive the SetDynamicMetadataProcessor object
+  std::string metadata_key_;
+  DynamicFunctionProcessorSharedPtr metadata_value_ = nullptr;
 };
 
 } // namespace HeaderRewriteFilter

--- a/header-rewrite-filter/header_processor_test.cc
+++ b/header-rewrite-filter/header_processor_test.cc
@@ -33,7 +33,7 @@ TEST_F(ProcessorTest, SetHeaderProcessorTest) {
 
     for (const auto operation_expression : positive_test_cases) {
         std::vector<absl::string_view> tokens = StringUtil::splitToken(operation_expression, " ", false, true);
-        SetHeaderProcessor set_header_processor = SetHeaderProcessor();
+        SetHeaderProcessor set_header_processor = SetHeaderProcessor(nullptr, (tokens.at(0) == "http-request"));
         Http::TestRequestHeaderMapImpl headers{
             {":method", "GET"}, {":path", "/"}, {":authority", "host"}};
         absl::Status status = set_header_processor.parseOperation(tokens, (tokens.begin() + 2));
@@ -45,7 +45,7 @@ TEST_F(ProcessorTest, SetHeaderProcessorTest) {
 
     for (const auto operation_expression : negative_test_cases) {
         std::vector<absl::string_view> tokens = StringUtil::splitToken(operation_expression, " ", false, true);
-        SetHeaderProcessor set_header_processor = SetHeaderProcessor();
+        SetHeaderProcessor set_header_processor = SetHeaderProcessor(nullptr, true);
         Http::TestRequestHeaderMapImpl headers{
             {":method", "GET"}, {":path", "/"}, {":authority", "host"}};
         absl::Status status = set_header_processor.parseOperation(tokens, (tokens.begin() + 2));
@@ -54,7 +54,7 @@ TEST_F(ProcessorTest, SetHeaderProcessorTest) {
 }
 
 TEST_F(ProcessorTest, AppendHeaderProcessorTest) {
-    AppendHeaderProcessor append_header_processor = AppendHeaderProcessor();
+    AppendHeaderProcessor append_header_processor = AppendHeaderProcessor(nullptr, true);
     Http::TestRequestHeaderMapImpl headers{
         {":method", "GET"}, {":path", "/"}, {":authority", "host"}};
 
@@ -67,7 +67,7 @@ TEST_F(ProcessorTest, AppendHeaderProcessorTest) {
     EXPECT_EQ("mock_value", headers.get(Http::LowerCaseString("mock_header"))[0]->value().getStringView());
 
     // can set multiple values
-    operation_expression = {"http-response", "append-header", "mock_key", "mock_val1", "mock_val2"};
+    operation_expression = {"http-request", "append-header", "mock_key", "mock_val1", "mock_val2"};
     status = append_header_processor.parseOperation(operation_expression, (operation_expression.begin() + 2));
     EXPECT_TRUE(status == absl::OkStatus());
     status = append_header_processor.executeOperation(headers, nullptr);
@@ -81,7 +81,7 @@ TEST_F(ProcessorTest, AppendHeaderProcessorTest) {
 
     for (const auto operation_expression : negative_test_cases) {
         std::vector<absl::string_view> tokens = StringUtil::splitToken(operation_expression, " ", false, true);
-        AppendHeaderProcessor append_header_processor = AppendHeaderProcessor();
+        AppendHeaderProcessor append_header_processor = AppendHeaderProcessor(nullptr, (tokens.at(0) == "http-request"));
         Http::TestRequestHeaderMapImpl headers{
             {":method", "GET"}, {":path", "/"}, {":authority", "host"}};
         absl::Status status = append_header_processor.parseOperation(tokens, (tokens.begin() + 2));
@@ -104,7 +104,7 @@ TEST_F(ProcessorTest, SetPathProcessorTest) {
 
     for (const auto operation_expression : positive_test_cases) {
         std::vector<absl::string_view> tokens = StringUtil::splitToken(operation_expression, " ", false, true);
-        SetPathProcessor set_path_processor = SetPathProcessor();
+        SetPathProcessor set_path_processor = SetPathProcessor(nullptr, (tokens.at(0) == "http-request"));
         Http::TestRequestHeaderMapImpl headers{
             {":method", "GET"}, {":path", "/?param=1"}, {":authority", "host"}};
         absl::Status status = set_path_processor.parseOperation(tokens, (tokens.begin() + 2));
@@ -117,7 +117,7 @@ TEST_F(ProcessorTest, SetPathProcessorTest) {
 
     for (const auto operation_expression : negative_test_cases) {
         std::vector<absl::string_view> tokens = StringUtil::splitToken(operation_expression, " ", false, true);
-        SetPathProcessor set_path_processor = SetPathProcessor();
+        SetPathProcessor set_path_processor = SetPathProcessor(nullptr, (tokens.at(0) == "http-request"));
         Http::TestRequestHeaderMapImpl headers{
             {":method", "GET"}, {":path", "/"}, {":authority", "host"}};
         absl::Status status = set_path_processor.parseOperation(tokens, (tokens.begin() + 2));
@@ -127,43 +127,43 @@ TEST_F(ProcessorTest, SetPathProcessorTest) {
 
 TEST_F(ProcessorTest, SetBoolProcessorTest) {
     std::vector<absl::string_view> true_match_test_cases = {
-        "http-request set-bool mock_bool hdr(mock_header1) -m str mock_value3", // exact, hdr 1 arg
-        "http-request set-bool mock_bool hdr(mock_header1,-1) -m str mock_value3", // exact, hdr 2 arg
-        "http-request set-bool mock_bool hdr(mock_header1,0) -m str mock_value1", // exact, hdr 2 arg
-        "http-request set-bool mock_bool hdr(mock_header1,-3) -m str mock_value1", // exact, hdr 2 arg
-        "http-request set-bool mock_bool hdr(mock_header2) -m beg mo", // prefix
-        "http-request set-bool mock_bool urlp(param1) -m beg so", // prefix, urlp
-        "http-request set-bool mock_bool hdr(mock_header2) -m sub lue", // substring
-        "http-request set-bool mock_bool hdr(mock_header2) -m found", // found, hdr
-        "http-request set-bool mock_bool urlp(param2) -m found" // found, urlp
+        "http-request set-bool mock_bool %[hdr(mock_header1)] -m str mock_value3", // exact, hdr 1 arg
+        "http-request set-bool mock_bool %[hdr(mock_header1,-1)] -m str mock_value3", // exact, hdr 2 arg
+        "http-request set-bool mock_bool %[hdr(mock_header1,0)] -m str mock_value1", // exact, hdr 2 arg
+        "http-request set-bool mock_bool %[hdr(mock_header1,-3)] -m str mock_value1", // exact, hdr 2 arg
+        "http-request set-bool mock_bool %[hdr(mock_header2)] -m beg mo", // prefix
+        "http-request set-bool mock_bool %[urlp(param1)] -m beg so", // prefix, urlp
+        "http-request set-bool mock_bool %[hdr(mock_header2)] -m sub lue", // substring
+        "http-request set-bool mock_bool %[hdr(mock_header2)] -m found", // found, hdr
+        "http-request set-bool mock_bool %[urlp(param2)] -m found" // found, urlp
     };
 
     std::vector<absl::string_view> false_match_test_cases = {
-        "http-request set-bool mock_bool hdr(mock_header2) -m str no-match", // exact
-        "http-request set-bool mock_bool hdr(mock_header1) -m beg tch", // prefix
-        "http-request set-bool mock_bool hdr(mock_header2) -m sub not_a_substring", // substring
-        "http-request set-bool mock_bool hdr(unknown_header) -m found" // found
+        "http-request set-bool mock_bool %[hdr(mock_header2)] -m str no-match", // exact
+        "http-request set-bool mock_bool %[hdr(mock_header1)] -m beg tch", // prefix
+        "http-request set-bool mock_bool %[hdr(mock_header2)] -m sub not_a_substring", // substring
+        "http-request set-bool mock_bool %[hdr(unknown_header)] -m found" // found
     };
 
     std::vector<absl::string_view> negative_test_cases = {
-        "http-request set-bool mock_bool hdr(mock_header1) -m str", // missing argument
-        "http-request set-bool mock_bool hdr(mock_header1) -m", // missing argument
-        "http-response set-bool mock_bool urlp(param1) -m beg so", // urlp on response side
-        "http-request set-bool mock_bool urlp(param1) -m str arg extra_arg", // extra arg
-        "http-request set-bool mock_bool urlp(param1) -m found extra_arg", // extra arg
-        "http-request set-bool mock_bool urlp(param2) str matches", // missing -m flag
-        "http-request set-bool mock_bool urlp(param2 -m found)" // invalid syntax
+        "http-request set-bool mock_bool %[hdr(mock_header1)] -m str", // missing argument
+        "http-request set-bool mock_bool %[hdr(mock_header1)] -m", // missing argument
+        "http-response set-bool mock_bool %[urlp(param1)] -m beg so", // urlp on response side
+        "http-request set-bool mock_bool %[urlp(param1)] -m str arg extra_arg", // extra arg
+        "http-request set-bool mock_bool %[urlp(param1)] -m found extra_arg", // extra arg
+        "http-request set-bool mock_bool %[urlp(param2)] str matches", // missing -m flag
+        "http-request set-bool mock_bool %[urlp(param2 -m found)]" // invalid syntax
     };
 
     for (const auto operation_expression : true_match_test_cases) {
         std::vector<absl::string_view> tokens = StringUtil::splitToken(operation_expression, " ", false, true);
-        SetBoolProcessor set_bool_processor = SetBoolProcessor();
+        SetBoolProcessor set_bool_processor = SetBoolProcessor(nullptr, (tokens.at(0) == "http-request"));
         Http::TestRequestHeaderMapImpl headers{
             {":method", "GET"}, {":path", "/?param1=something&param2=2"}, {":authority", "host"}, {"mock_header1", "mock_value1,mock_value2,mock_value3"}, {"mock_header2", "mock_value"}};
         absl::Status status = set_bool_processor.parseOperation(tokens, (tokens.begin() + 2));
         EXPECT_TRUE(status == absl::OkStatus());
         EXPECT_EQ(status.message(), "");
-        std::tuple<absl::Status, bool> result = set_bool_processor.executeOperation(headers, false);
+        std::tuple<absl::Status, bool> result = set_bool_processor.executeOperation(headers, nullptr, false);
         status = std::get<0>(result);
         bool bool_result = std::get<1>(result);
         EXPECT_TRUE(status == absl::OkStatus());
@@ -172,13 +172,13 @@ TEST_F(ProcessorTest, SetBoolProcessorTest) {
 
     for (const auto operation_expression : false_match_test_cases) {
         std::vector<absl::string_view> tokens = StringUtil::splitToken(operation_expression, " ", false, true);
-        SetBoolProcessor set_bool_processor = SetBoolProcessor();
+        SetBoolProcessor set_bool_processor = SetBoolProcessor(nullptr, (tokens.at(0) == "http-request"));
         Http::TestRequestHeaderMapImpl headers{
             {":method", "GET"}, {":path", "/?param1=1,param2=2"}, {":authority", "host"}, {"mock_header1", "mock_value1,mock_value2,mock_value3"}, {"mock_header2", "mock_value"}};
         absl::Status status = set_bool_processor.parseOperation(tokens, (tokens.begin() + 2));
         EXPECT_TRUE(status == absl::OkStatus());
         EXPECT_EQ(status.message(), "");
-        std::tuple<absl::Status, bool> result = set_bool_processor.executeOperation(headers, false);
+        std::tuple<absl::Status, bool> result = set_bool_processor.executeOperation(headers, nullptr, false);
         status = std::get<0>(result);
         bool bool_result = std::get<1>(result);
         EXPECT_TRUE(status == absl::OkStatus());
@@ -187,7 +187,7 @@ TEST_F(ProcessorTest, SetBoolProcessorTest) {
 
     for (const auto operation_expression : negative_test_cases) {
         std::vector<absl::string_view> tokens = StringUtil::splitToken(operation_expression, " ", false, true);
-        SetBoolProcessor set_bool_processor = SetBoolProcessor();
+        SetBoolProcessor set_bool_processor = SetBoolProcessor(nullptr, (tokens.at(0) == "http-request"));
         Http::TestRequestHeaderMapImpl headers{
             {":method", "GET"}, {":path", "/?param1=1,param2=2"}, {":authority", "host"}, {"mock_header1", "mock_value1,mock_value2,mock_value3"}, {"mock_header2", "mock_value"}};
         absl::Status status = set_bool_processor.parseOperation(tokens, (tokens.begin() + 2));
@@ -200,14 +200,14 @@ TEST_F(ProcessorTest, ConditionProcessorTest) {
             {":method", "GET"}, {":path", "/"}, {":authority", "host"}, {"mock_header", "mock_value"}};
             
     SetBoolProcessorMapSharedPtr mock_bool_processors = std::make_shared<std::unordered_map<std::string, SetBoolProcessorSharedPtr>>();
-    SetBoolProcessorSharedPtr mock_true_bool_processor = std::make_shared<SetBoolProcessor>();
-    SetBoolProcessorSharedPtr mock_false_bool_processor = std::make_shared<SetBoolProcessor>();
+    SetBoolProcessorSharedPtr mock_true_bool_processor = std::make_shared<SetBoolProcessor>(mock_bool_processors, true);
+    SetBoolProcessorSharedPtr mock_false_bool_processor = std::make_shared<SetBoolProcessor>(mock_bool_processors, true);
 
     // set up mock bool processors
-    std::vector<absl::string_view> operation_expression = {"http", "set-bool", "mock_true_bool", "hdr(mock_header)", "-m", "str", "mock_value"};
+    std::vector<absl::string_view> operation_expression = {"http", "set-bool", "mock_true_bool", "%[hdr(mock_header)]", "-m", "str", "mock_value"};
     absl::Status status = mock_true_bool_processor->parseOperation(operation_expression, (operation_expression.begin() + 2));
     EXPECT_TRUE(status == absl::OkStatus());
-    operation_expression = {"http", "set-bool", "mock_false_bool", "hdr(mock_header)", "-m", "str", "not-a-match"};
+    operation_expression = {"http", "set-bool", "mock_false_bool", "%[hdr(mock_header)]", "-m", "str", "not-a-match"};
     status = mock_false_bool_processor->parseOperation(operation_expression, (operation_expression.begin() + 2));
     EXPECT_TRUE(status == absl::OkStatus());
     mock_bool_processors->insert({"mock_true_bool", mock_true_bool_processor});
@@ -236,19 +236,16 @@ TEST_F(ProcessorTest, ConditionProcessorTest) {
         "and mock_true_bool",
         "mock_true_bool and or mock_true_bool",
         "mock_true_bool not and mock_true_bool",
-        "mock_true_bool and mock_true_bool not"
-    };
-
-    std::vector<absl::string_view> invalid_execution_test_cases = {
+        "mock_true_bool and mock_true_bool not",
         "non_existent_bool"
     };
 
     for (const auto operation_expression : true_condition_test_cases) {
         std::vector<absl::string_view> tokens = StringUtil::splitToken(operation_expression, " ", false, true);
-        ConditionProcessor condition_processor = ConditionProcessor();
+        ConditionProcessor condition_processor = ConditionProcessor(mock_bool_processors, true);
         absl::Status status = condition_processor.parseOperation(tokens, tokens.begin());
         EXPECT_TRUE(status == absl::OkStatus());
-        std::tuple<absl::Status, bool> result = condition_processor.executeOperation(headers, mock_bool_processors);
+        std::tuple<absl::Status, bool> result = condition_processor.executeOperation(headers, nullptr);
         status = std::get<0>(result);
         EXPECT_TRUE(status == absl::OkStatus());
         bool bool_result = std::get<1>(result);
@@ -257,10 +254,10 @@ TEST_F(ProcessorTest, ConditionProcessorTest) {
 
     for (const auto operation_expression : false_condition_test_cases) {
         std::vector<absl::string_view> tokens = StringUtil::splitToken(operation_expression, " ", false, true);
-        ConditionProcessor condition_processor = ConditionProcessor();
+        ConditionProcessor condition_processor = ConditionProcessor(mock_bool_processors, true);
         absl::Status status = condition_processor.parseOperation(tokens, tokens.begin());
         EXPECT_TRUE(status == absl::OkStatus());
-        std::tuple<absl::Status, bool> result = condition_processor.executeOperation(headers, mock_bool_processors);
+        std::tuple<absl::Status, bool> result = condition_processor.executeOperation(headers, nullptr);
         status = std::get<0>(result);
         EXPECT_TRUE(status == absl::OkStatus());
         bool bool_result = std::get<1>(result);
@@ -269,18 +266,8 @@ TEST_F(ProcessorTest, ConditionProcessorTest) {
 
     for (const auto operation_expression : invalid_parsing_test_cases) {
         std::vector<absl::string_view> tokens = StringUtil::splitToken(operation_expression, " ", false, true);
-        ConditionProcessor condition_processor = ConditionProcessor();
+        ConditionProcessor condition_processor = ConditionProcessor(mock_bool_processors, true);
         absl::Status status = condition_processor.parseOperation(tokens, tokens.begin());
-        EXPECT_TRUE(status.code() == absl::StatusCode::kInvalidArgument);
-    }
-
-    for (const auto operation_expression : invalid_execution_test_cases) {
-        std::vector<absl::string_view> tokens = StringUtil::splitToken(operation_expression, " ", false, true);
-        ConditionProcessor condition_processor = ConditionProcessor();
-        absl::Status status = condition_processor.parseOperation(tokens, tokens.begin());
-        EXPECT_TRUE(status == absl::OkStatus());
-        std::tuple<absl::Status, bool> result = condition_processor.executeOperation(headers, mock_bool_processors);
-        status = std::get<0>(result);
         EXPECT_TRUE(status.code() == absl::StatusCode::kInvalidArgument);
     }
 }

--- a/header-rewrite-filter/header_processor_test.cc
+++ b/header-rewrite-filter/header_processor_test.cc
@@ -33,19 +33,19 @@ TEST_F(ProcessorTest, SetHeaderProcessorTest) {
 
     for (const auto operation_expression : positive_test_cases) {
         std::vector<absl::string_view> tokens = StringUtil::splitToken(operation_expression, " ", false, true);
-        SetHeaderProcessor set_header_processor = SetHeaderProcessor();
+        SetHeaderProcessor set_header_processor = SetHeaderProcessor(nullptr, nullptr, (tokens.at(0) == "http-request"));
         Http::TestRequestHeaderMapImpl headers{
             {":method", "GET"}, {":path", "/"}, {":authority", "host"}};
         absl::Status status = set_header_processor.parseOperation(tokens, (tokens.begin() + 2));
         EXPECT_TRUE(status == absl::OkStatus());
-        status = set_header_processor.executeOperation(headers, nullptr);
+        status = set_header_processor.executeOperation(headers);
         EXPECT_TRUE(status == absl::OkStatus());
         EXPECT_EQ(tokens.at(3), headers.get(Http::LowerCaseString(tokens.at(2)))[0]->value().getStringView());
     }
 
     for (const auto operation_expression : negative_test_cases) {
         std::vector<absl::string_view> tokens = StringUtil::splitToken(operation_expression, " ", false, true);
-        SetHeaderProcessor set_header_processor = SetHeaderProcessor();
+        SetHeaderProcessor set_header_processor = SetHeaderProcessor(nullptr, nullptr, true);
         Http::TestRequestHeaderMapImpl headers{
             {":method", "GET"}, {":path", "/"}, {":authority", "host"}};
         absl::Status status = set_header_processor.parseOperation(tokens, (tokens.begin() + 2));
@@ -54,7 +54,7 @@ TEST_F(ProcessorTest, SetHeaderProcessorTest) {
 }
 
 TEST_F(ProcessorTest, AppendHeaderProcessorTest) {
-    AppendHeaderProcessor append_header_processor = AppendHeaderProcessor();
+    AppendHeaderProcessor append_header_processor = AppendHeaderProcessor(nullptr, nullptr, true);
     Http::TestRequestHeaderMapImpl headers{
         {":method", "GET"}, {":path", "/"}, {":authority", "host"}};
 
@@ -62,15 +62,15 @@ TEST_F(ProcessorTest, AppendHeaderProcessorTest) {
     std::vector<absl::string_view> operation_expression({"http-request", "append-header", "mock_header", "mock_value"});
     absl::Status status = append_header_processor.parseOperation(operation_expression, (operation_expression.begin() + 2));
     EXPECT_TRUE(status == absl::OkStatus());
-    status = append_header_processor.executeOperation(headers, nullptr);
+    status = append_header_processor.executeOperation(headers);
     EXPECT_TRUE(status == absl::OkStatus());
     EXPECT_EQ("mock_value", headers.get(Http::LowerCaseString("mock_header"))[0]->value().getStringView());
 
     // can set multiple values
-    operation_expression = {"http-response", "append-header", "mock_key", "mock_val1", "mock_val2"};
+    operation_expression = {"http-request", "append-header", "mock_key", "mock_val1", "mock_val2"};
     status = append_header_processor.parseOperation(operation_expression, (operation_expression.begin() + 2));
     EXPECT_TRUE(status == absl::OkStatus());
-    status = append_header_processor.executeOperation(headers, nullptr);
+    status = append_header_processor.executeOperation(headers);
     EXPECT_TRUE(status == absl::OkStatus());
     EXPECT_EQ("mock_val1,mock_val2", headers.get(Http::LowerCaseString("mock_key"))[0]->value().getStringView());
 
@@ -81,7 +81,7 @@ TEST_F(ProcessorTest, AppendHeaderProcessorTest) {
 
     for (const auto operation_expression : negative_test_cases) {
         std::vector<absl::string_view> tokens = StringUtil::splitToken(operation_expression, " ", false, true);
-        AppendHeaderProcessor append_header_processor = AppendHeaderProcessor();
+        AppendHeaderProcessor append_header_processor = AppendHeaderProcessor(nullptr, nullptr, (tokens.at(0) == "http-request"));
         Http::TestRequestHeaderMapImpl headers{
             {":method", "GET"}, {":path", "/"}, {":authority", "host"}};
         absl::Status status = append_header_processor.parseOperation(tokens, (tokens.begin() + 2));
@@ -104,12 +104,12 @@ TEST_F(ProcessorTest, SetPathProcessorTest) {
 
     for (const auto operation_expression : positive_test_cases) {
         std::vector<absl::string_view> tokens = StringUtil::splitToken(operation_expression, " ", false, true);
-        SetPathProcessor set_path_processor = SetPathProcessor();
+        SetPathProcessor set_path_processor = SetPathProcessor(nullptr, nullptr, (tokens.at(0) == "http-request"));
         Http::TestRequestHeaderMapImpl headers{
             {":method", "GET"}, {":path", "/?param=1"}, {":authority", "host"}};
         absl::Status status = set_path_processor.parseOperation(tokens, (tokens.begin() + 2));
         EXPECT_TRUE(status == absl::OkStatus());
-        status = set_path_processor.executeOperation(headers, nullptr);
+        status = set_path_processor.executeOperation(headers);
         EXPECT_TRUE(status == absl::OkStatus());
         std::string expected_path = std::string(tokens.at(2)) + "?param=1";
         EXPECT_EQ(expected_path, headers.get(Http::LowerCaseString(":path"))[0]->value().getStringView());
@@ -117,7 +117,7 @@ TEST_F(ProcessorTest, SetPathProcessorTest) {
 
     for (const auto operation_expression : negative_test_cases) {
         std::vector<absl::string_view> tokens = StringUtil::splitToken(operation_expression, " ", false, true);
-        SetPathProcessor set_path_processor = SetPathProcessor();
+        SetPathProcessor set_path_processor = SetPathProcessor(nullptr, nullptr, (tokens.at(0) == "http-request"));
         Http::TestRequestHeaderMapImpl headers{
             {":method", "GET"}, {":path", "/"}, {":authority", "host"}};
         absl::Status status = set_path_processor.parseOperation(tokens, (tokens.begin() + 2));
@@ -127,37 +127,37 @@ TEST_F(ProcessorTest, SetPathProcessorTest) {
 
 TEST_F(ProcessorTest, SetBoolProcessorTest) {
     std::vector<absl::string_view> true_match_test_cases = {
-        "http-request set-bool mock_bool hdr(mock_header1) -m str mock_value3", // exact, hdr 1 arg
-        "http-request set-bool mock_bool hdr(mock_header1,-1) -m str mock_value3", // exact, hdr 2 arg
-        "http-request set-bool mock_bool hdr(mock_header1,0) -m str mock_value1", // exact, hdr 2 arg
-        "http-request set-bool mock_bool hdr(mock_header1,-3) -m str mock_value1", // exact, hdr 2 arg
-        "http-request set-bool mock_bool hdr(mock_header2) -m beg mo", // prefix
-        "http-request set-bool mock_bool urlp(param1) -m beg so", // prefix, urlp
-        "http-request set-bool mock_bool hdr(mock_header2) -m sub lue", // substring
-        "http-request set-bool mock_bool hdr(mock_header2) -m found", // found, hdr
-        "http-request set-bool mock_bool urlp(param2) -m found" // found, urlp
+        "http-request set-bool mock_bool %[hdr(mock_header1)] -m str mock_value3", // exact, hdr 1 arg
+        "http-request set-bool mock_bool %[hdr(mock_header1,-1)] -m str mock_value3", // exact, hdr 2 arg
+        "http-request set-bool mock_bool %[hdr(mock_header1,0)] -m str mock_value1", // exact, hdr 2 arg
+        "http-request set-bool mock_bool %[hdr(mock_header1,-3)] -m str mock_value1", // exact, hdr 2 arg
+        "http-request set-bool mock_bool %[hdr(mock_header2)] -m beg mo", // prefix
+        "http-request set-bool mock_bool %[urlp(param1)] -m beg so", // prefix, urlp
+        "http-request set-bool mock_bool %[hdr(mock_header2)] -m sub lue", // substring
+        "http-request set-bool mock_bool %[hdr(mock_header2)] -m found", // found, hdr
+        "http-request set-bool mock_bool %[urlp(param2)] -m found" // found, urlp
     };
 
     std::vector<absl::string_view> false_match_test_cases = {
-        "http-request set-bool mock_bool hdr(mock_header2) -m str no-match", // exact
-        "http-request set-bool mock_bool hdr(mock_header1) -m beg tch", // prefix
-        "http-request set-bool mock_bool hdr(mock_header2) -m sub not_a_substring", // substring
-        "http-request set-bool mock_bool hdr(unknown_header) -m found" // found
+        "http-request set-bool mock_bool %[hdr(mock_header2)] -m str no-match", // exact
+        "http-request set-bool mock_bool %[hdr(mock_header1)] -m beg tch", // prefix
+        "http-request set-bool mock_bool %[hdr(mock_header2)] -m sub not_a_substring", // substring
+        "http-request set-bool mock_bool %[hdr(unknown_header)] -m found" // found
     };
 
     std::vector<absl::string_view> negative_test_cases = {
-        "http-request set-bool mock_bool hdr(mock_header1) -m str", // missing argument
-        "http-request set-bool mock_bool hdr(mock_header1) -m", // missing argument
-        "http-response set-bool mock_bool urlp(param1) -m beg so", // urlp on response side
-        "http-request set-bool mock_bool urlp(param1) -m str arg extra_arg", // extra arg
-        "http-request set-bool mock_bool urlp(param1) -m found extra_arg", // extra arg
-        "http-request set-bool mock_bool urlp(param2) str matches", // missing -m flag
-        "http-request set-bool mock_bool urlp(param2 -m found)" // invalid syntax
+        "http-request set-bool mock_bool %[hdr(mock_header1)] -m str", // missing argument
+        "http-request set-bool mock_bool %[hdr(mock_header1)] -m", // missing argument
+        "http-response set-bool mock_bool %[urlp(param1)] -m beg so", // urlp on response side
+        "http-request set-bool mock_bool %[urlp(param1)] -m str arg extra_arg", // extra arg
+        "http-request set-bool mock_bool %[urlp(param1)] -m found extra_arg", // extra arg
+        "http-request set-bool mock_bool %[urlp(param2)] str matches", // missing -m flag
+        "http-request set-bool mock_bool %[urlp(param2 -m found)]" // invalid syntax
     };
 
     for (const auto operation_expression : true_match_test_cases) {
         std::vector<absl::string_view> tokens = StringUtil::splitToken(operation_expression, " ", false, true);
-        SetBoolProcessor set_bool_processor = SetBoolProcessor();
+        SetBoolProcessor set_bool_processor = SetBoolProcessor(nullptr, nullptr, (tokens.at(0) == "http-request"));
         Http::TestRequestHeaderMapImpl headers{
             {":method", "GET"}, {":path", "/?param1=something&param2=2"}, {":authority", "host"}, {"mock_header1", "mock_value1,mock_value2,mock_value3"}, {"mock_header2", "mock_value"}};
         absl::Status status = set_bool_processor.parseOperation(tokens, (tokens.begin() + 2));
@@ -172,7 +172,7 @@ TEST_F(ProcessorTest, SetBoolProcessorTest) {
 
     for (const auto operation_expression : false_match_test_cases) {
         std::vector<absl::string_view> tokens = StringUtil::splitToken(operation_expression, " ", false, true);
-        SetBoolProcessor set_bool_processor = SetBoolProcessor();
+        SetBoolProcessor set_bool_processor = SetBoolProcessor(nullptr, nullptr, (tokens.at(0) == "http-request"));
         Http::TestRequestHeaderMapImpl headers{
             {":method", "GET"}, {":path", "/?param1=1,param2=2"}, {":authority", "host"}, {"mock_header1", "mock_value1,mock_value2,mock_value3"}, {"mock_header2", "mock_value"}};
         absl::Status status = set_bool_processor.parseOperation(tokens, (tokens.begin() + 2));
@@ -187,7 +187,7 @@ TEST_F(ProcessorTest, SetBoolProcessorTest) {
 
     for (const auto operation_expression : negative_test_cases) {
         std::vector<absl::string_view> tokens = StringUtil::splitToken(operation_expression, " ", false, true);
-        SetBoolProcessor set_bool_processor = SetBoolProcessor();
+        SetBoolProcessor set_bool_processor = SetBoolProcessor(nullptr, nullptr, (tokens.at(0) == "http-request"));
         Http::TestRequestHeaderMapImpl headers{
             {":method", "GET"}, {":path", "/?param1=1,param2=2"}, {":authority", "host"}, {"mock_header1", "mock_value1,mock_value2,mock_value3"}, {"mock_header2", "mock_value"}};
         absl::Status status = set_bool_processor.parseOperation(tokens, (tokens.begin() + 2));
@@ -200,14 +200,14 @@ TEST_F(ProcessorTest, ConditionProcessorTest) {
             {":method", "GET"}, {":path", "/"}, {":authority", "host"}, {"mock_header", "mock_value"}};
             
     SetBoolProcessorMapSharedPtr mock_bool_processors = std::make_shared<std::unordered_map<std::string, SetBoolProcessorSharedPtr>>();
-    SetBoolProcessorSharedPtr mock_true_bool_processor = std::make_shared<SetBoolProcessor>();
-    SetBoolProcessorSharedPtr mock_false_bool_processor = std::make_shared<SetBoolProcessor>();
+    SetBoolProcessorSharedPtr mock_true_bool_processor = std::make_shared<SetBoolProcessor>(mock_bool_processors, nullptr, true);
+    SetBoolProcessorSharedPtr mock_false_bool_processor = std::make_shared<SetBoolProcessor>(mock_bool_processors, nullptr, true);
 
     // set up mock bool processors
-    std::vector<absl::string_view> operation_expression = {"http", "set-bool", "mock_true_bool", "hdr(mock_header)", "-m", "str", "mock_value"};
+    std::vector<absl::string_view> operation_expression = {"http", "set-bool", "mock_true_bool", "%[hdr(mock_header)]", "-m", "str", "mock_value"};
     absl::Status status = mock_true_bool_processor->parseOperation(operation_expression, (operation_expression.begin() + 2));
     EXPECT_TRUE(status == absl::OkStatus());
-    operation_expression = {"http", "set-bool", "mock_false_bool", "hdr(mock_header)", "-m", "str", "not-a-match"};
+    operation_expression = {"http", "set-bool", "mock_false_bool", "%[hdr(mock_header)]", "-m", "str", "not-a-match"};
     status = mock_false_bool_processor->parseOperation(operation_expression, (operation_expression.begin() + 2));
     EXPECT_TRUE(status == absl::OkStatus());
     mock_bool_processors->insert({"mock_true_bool", mock_true_bool_processor});
@@ -236,19 +236,16 @@ TEST_F(ProcessorTest, ConditionProcessorTest) {
         "and mock_true_bool",
         "mock_true_bool and or mock_true_bool",
         "mock_true_bool not and mock_true_bool",
-        "mock_true_bool and mock_true_bool not"
-    };
-
-    std::vector<absl::string_view> invalid_execution_test_cases = {
+        "mock_true_bool and mock_true_bool not",
         "non_existent_bool"
     };
 
     for (const auto operation_expression : true_condition_test_cases) {
         std::vector<absl::string_view> tokens = StringUtil::splitToken(operation_expression, " ", false, true);
-        ConditionProcessor condition_processor = ConditionProcessor();
+        ConditionProcessor condition_processor = ConditionProcessor(mock_bool_processors, nullptr, true);
         absl::Status status = condition_processor.parseOperation(tokens, tokens.begin());
         EXPECT_TRUE(status == absl::OkStatus());
-        std::tuple<absl::Status, bool> result = condition_processor.executeOperation(headers, mock_bool_processors);
+        std::tuple<absl::Status, bool> result = condition_processor.executeOperation(headers);
         status = std::get<0>(result);
         EXPECT_TRUE(status == absl::OkStatus());
         bool bool_result = std::get<1>(result);
@@ -257,10 +254,10 @@ TEST_F(ProcessorTest, ConditionProcessorTest) {
 
     for (const auto operation_expression : false_condition_test_cases) {
         std::vector<absl::string_view> tokens = StringUtil::splitToken(operation_expression, " ", false, true);
-        ConditionProcessor condition_processor = ConditionProcessor();
+        ConditionProcessor condition_processor = ConditionProcessor(mock_bool_processors, nullptr, true);
         absl::Status status = condition_processor.parseOperation(tokens, tokens.begin());
         EXPECT_TRUE(status == absl::OkStatus());
-        std::tuple<absl::Status, bool> result = condition_processor.executeOperation(headers, mock_bool_processors);
+        std::tuple<absl::Status, bool> result = condition_processor.executeOperation(headers);
         status = std::get<0>(result);
         EXPECT_TRUE(status == absl::OkStatus());
         bool bool_result = std::get<1>(result);
@@ -269,18 +266,8 @@ TEST_F(ProcessorTest, ConditionProcessorTest) {
 
     for (const auto operation_expression : invalid_parsing_test_cases) {
         std::vector<absl::string_view> tokens = StringUtil::splitToken(operation_expression, " ", false, true);
-        ConditionProcessor condition_processor = ConditionProcessor();
+        ConditionProcessor condition_processor = ConditionProcessor(mock_bool_processors, nullptr, true);
         absl::Status status = condition_processor.parseOperation(tokens, tokens.begin());
-        EXPECT_TRUE(status.code() == absl::StatusCode::kInvalidArgument);
-    }
-
-    for (const auto operation_expression : invalid_execution_test_cases) {
-        std::vector<absl::string_view> tokens = StringUtil::splitToken(operation_expression, " ", false, true);
-        ConditionProcessor condition_processor = ConditionProcessor();
-        absl::Status status = condition_processor.parseOperation(tokens, tokens.begin());
-        EXPECT_TRUE(status == absl::OkStatus());
-        std::tuple<absl::Status, bool> result = condition_processor.executeOperation(headers, mock_bool_processors);
-        status = std::get<0>(result);
         EXPECT_TRUE(status.code() == absl::StatusCode::kInvalidArgument);
     }
 }

--- a/header-rewrite-filter/utility.cc
+++ b/header-rewrite-filter/utility.cc
@@ -15,6 +15,8 @@ namespace Utility {
         return OperationType::SetPath;
     } else if (operation == OPERATION_SET_BOOL) {
         return OperationType::SetBool;
+    } else if (operation == OPERATION_SET_DYN_METADATA) {
+        return OperationType::SetDynMetadata;
     } else {
         return OperationType::InvalidOperation;
     }

--- a/header-rewrite-filter/utility.h
+++ b/header-rewrite-filter/utility.h
@@ -12,16 +12,22 @@ namespace HttpFilters {
 namespace HeaderRewriteFilter {
 namespace Utility {
 
+constexpr absl::string_view HEADER_REWRITE_FILTER_NAME = "envoy.extensions.filters.http.HeaderRewrite";
+
 constexpr uint8_t MIN_NUM_ARGUMENTS = 2;
 constexpr uint8_t SET_HEADER_MIN_NUM_ARGUMENTS = 4;
 constexpr uint8_t APPEND_HEADER_MIN_NUM_ARGUMENTS = 4;
+constexpr uint8_t SET_DYN_METADATA_MIN_NUM_ARGUMENTS = 4;
 constexpr uint8_t SET_PATH_MIN_NUM_ARGUMENTS = 3;
 constexpr uint8_t SET_BOOL_MIN_NUM_ARGUMENTS = 6;
+
+constexpr absl::string_view DYNAMIC_FUNCTION_DELIMITER = "%[]";
 
 constexpr absl::string_view OPERATION_SET_HEADER = "set-header";
 constexpr absl::string_view OPERATION_APPEND_HEADER = "append-header";
 constexpr absl::string_view OPERATION_SET_PATH = "set-path";
 constexpr absl::string_view OPERATION_SET_BOOL = "set-bool";
+constexpr absl::string_view OPERATION_SET_DYN_METADATA = "set-metadata";
 
 constexpr absl::string_view IF_KEYWORD = "if";
 
@@ -45,6 +51,7 @@ enum class OperationType : int {
   AppendHeader,
   SetPath,
   SetBool,
+  SetDynMetadata,
   InvalidOperation,
 };
 


### PR DESCRIPTION
This PR implements being able to set a key-value pair in the header rewrite filter's dynamic metadata. Unit tests were also updated. (Jira: [EDGEBE-456](https://datadoghq.atlassian.net/browse/EDGEBE-456))

Summary of minor changes packaged in this PR:
- All dynamic function calls are now wrapped with `%[]` -- otherwise config parsing will return an error
- Bool processor maps are now passed into `processors` at filter setup time -- a future PR will similarly pass variable maps (associated with the `set-var` operation) into each processor constructor
- Trying to access a non-existent bool value will now fail at parse time rather than execute time -- motivation for this change is to rightly fail an operation that tries to access a boolean variable that is created later on in the filter config

## Testing
Sample config:
```
http-request set-bool true_bool %[hdr(mock_header,-1)] -m str mock_val
http-request set-header mock_header mock_val
http-request set-metadata mock_key %[hdr(mock_header,-1)]
http-request set-metadata mock_key %[urlp(param1)]
```

Start envoy and send a curl request:
```
$ curl -v localhost:8081?param1=hello
*   Trying 127.0.0.1:8081...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8081 (#0)
> GET /?param1=hello HTTP/1.1
> Host: localhost:8081
> User-Agent: curl/7.68.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< x-envoy-upstream-service-time: 0
< date: Fri, 11 Aug 2023 17:51:08 GMT
< server: envoy
< transfer-encoding: chunked
< 
* Connection #0 to host localhost left intact
```

Envoy logs confirm that metadata is set to the right value both times:
```
[2023-08-11 17:51:07.178][2535636][info][main] [external/envoy/source/server/server.cc:937] starting main dispatch loop
[2023-08-11 17:51:08.936][2535698][info][misc] [header-rewrite-filter/header_processor.cc:630] set metadata
[2023-08-11 17:51:08.936][2535698][info][misc] [header-rewrite-filter/header_processor.cc:640] string value is mock_val
[2023-08-11 17:51:08.936][2535698][info][misc] [header-rewrite-filter/header_processor.cc:630] set metadata
[2023-08-11 17:51:08.936][2535698][info][misc] [header-rewrite-filter/header_processor.cc:640] string value is hello
```

Unit tests:
```
==================== Test output for //header-rewrite-filter:header_processor_test:
[==========] Running 5 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 5 tests from ProcessorTest
[ RUN      ] ProcessorTest.SetHeaderProcessorTest
[       OK ] ProcessorTest.SetHeaderProcessorTest (2 ms)
[ RUN      ] ProcessorTest.AppendHeaderProcessorTest
[       OK ] ProcessorTest.AppendHeaderProcessorTest (0 ms)
[ RUN      ] ProcessorTest.SetPathProcessorTest
[       OK ] ProcessorTest.SetPathProcessorTest (0 ms)
[ RUN      ] ProcessorTest.SetBoolProcessorTest
[       OK ] ProcessorTest.SetBoolProcessorTest (1 ms)
[ RUN      ] ProcessorTest.ConditionProcessorTest
[       OK ] ProcessorTest.ConditionProcessorTest (0 ms)
[----------] 5 tests from ProcessorTest (5 ms total)

[----------] Global test environment tear-down
[==========] 5 tests from 1 test suite ran. (5 ms total)
[  PASSED  ] 5 tests.
================================================================================
Target //header-rewrite-filter:header_processor_test up-to-date:
  bazel-bin/header-rewrite-filter/header_processor_test
INFO: Elapsed time: 81.444s, Critical Path: 80.99s
INFO: 4 processes: 1 internal, 3 linux-sandbox.
INFO: Build completed successfully, 4 total actions

Executed 1 out of 1 test: 1 test passes.
```

[EDGEBE-456]: https://datadoghq.atlassian.net/browse/EDGEBE-456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ