### PR TITLE
modified dynamic function processor to also handle static values

### DIFF
--- a/header-rewrite-filter/header_processor.h
+++ b/header-rewrite-filter/header_processor.h
@@ -95,15 +95,8 @@ public:
   virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start);
   virtual absl::Status executeOperation(Http::RequestOrResponseHeaderMap& headers, Envoy::StreamInfo::StreamInfo* streamInfo);
 private:
-  // Note: the values returned by these functions must not outlive the SetHeaderProcessor object
-  const absl::string_view getKey() const { return header_key_; }
-  const std::string getVal() const { return header_val_; }
-
-  void setKey(absl::string_view key) { header_key_ = std::string(key); }
-  void setVal(absl::string_view val) { header_val_ = std::string(val); }
-
-  std::string header_key_; // header key to set
-  std::string header_val_; // header value to set
+  DynamicFunctionProcessorSharedPtr header_key_ = nullptr; // header key to set
+  DynamicFunctionProcessorSharedPtr header_val_ = nullptr; // header value to set
 };
 
 class AppendHeaderProcessor : public HeaderProcessor {
@@ -114,15 +107,8 @@ public:
   virtual absl::Status executeOperation(Http::RequestOrResponseHeaderMap& headers, Envoy::StreamInfo::StreamInfo* streamInfo);
   
 private:
-  // Note: the values returned by these functions must not outlive the AppendHeaderProcessor object
-  const absl::string_view getKey() const { return header_key_; }
-  const std::vector<std::string>& getVals() const { return header_vals_; }
-
-  void setKey(absl::string_view key) { header_key_ = std::string(key); }
-  void setVals(std::vector<std::string> vals) { header_vals_ = vals; }
-
-  std::string header_key_; // header key to set
-  std::vector<std::string> header_vals_; // header values to set
+  DynamicFunctionProcessorSharedPtr header_key_ = nullptr; // header key to set
+  std::vector<DynamicFunctionProcessorSharedPtr> header_vals_; // header values to append
 };
 
 // Note: path being set here includes the query string
@@ -134,11 +120,7 @@ public:
   virtual absl::Status executeOperation(Http::RequestOrResponseHeaderMap& headers, Envoy::StreamInfo::StreamInfo* streamInfo);
 
 private:
-  // Note: the values returned by these functions must not outlive the SetHeaderProcessor object
-  const std::string& getPath() const { return request_path_; }
-  void setPath(absl::string_view path) { request_path_ = std::string(path); }
-
-  std::string request_path_; // path to set
+  DynamicFunctionProcessorSharedPtr request_path_; // path to set
 };
 
 class SetDynamicMetadataProcessor : public HeaderProcessor {
@@ -150,7 +132,7 @@ public:
 
 private:
   // Note: the values returned by these functions must not outlive the SetDynamicMetadataProcessor object
-  std::string metadata_key_;
+  DynamicFunctionProcessorSharedPtr metadata_key_ = nullptr;
   DynamicFunctionProcessorSharedPtr metadata_value_ = nullptr;
 };
 

--- a/header-rewrite-filter/header_processor_test.cc
+++ b/header-rewrite-filter/header_processor_test.cc
@@ -71,10 +71,11 @@ TEST_F(ProcessorTest, AppendHeaderProcessorTest) {
     EXPECT_EQ("mock_value", headers.get(Http::LowerCaseString("mock_header"))[0]->value().getStringView());
 
     // can set multiple values
+    AppendHeaderProcessor append_header_processor_multiple_values = AppendHeaderProcessor(nullptr, true);
     operation_expression = {"http-request", "append-header", "mock_key", "mock_val1", "mock_val2"};
-    status = append_header_processor.parseOperation(operation_expression, (operation_expression.begin() + 2));
+    status = append_header_processor_multiple_values.parseOperation(operation_expression, (operation_expression.begin() + 2));
     EXPECT_TRUE(status == absl::OkStatus());
-    status = append_header_processor.executeOperation(headers, stream_info);
+    status = append_header_processor_multiple_values.executeOperation(headers, stream_info);
     EXPECT_TRUE(status == absl::OkStatus());
     EXPECT_EQ("mock_val1,mock_val2", headers.get(Http::LowerCaseString("mock_key"))[0]->value().getStringView());
 

--- a/header-rewrite-filter/utility.h
+++ b/header-rewrite-filter/utility.h
@@ -74,6 +74,7 @@ enum class BooleanOperatorType : int {
 enum class FunctionType : int {
   GetHdr,
   Urlp,
+  Static,
   InvalidFunctionType
 };
 


### PR DESCRIPTION
## Description
Before this PR, every processor hard coded whether it expected a static value (string literal) or dynamic value (eg. req/res header, url path). This PR modifies the `Processor` interface to accept and parse either static or dynamic values. Every processor can now handle both cases.

Example:
`http-request set-header static_header_key %[hdr(dynamic_header_value)]` -- static key, dynamic value
`http-request set-header %[hdr(dynamic_header_key)] static_header_value` -- dynamic key, static value
(and so forth)

## Testing
- Ran end to end tests locally and verified that all operations were successfully executed
- Ran unit tests