### PR TITLE
implemented GetMetadata dynamic function

### DIFF
--- a/header-rewrite-filter/envoy-sample-config.yaml
+++ b/header-rewrite-filter/envoy-sample-config.yaml
@@ -56,6 +56,10 @@ static_resources:
                   http-response set-header mock_response_hdr mock_val if not false_bool
                   http-request set-metadata mock_key %[hdr(mock_header,-1)] if true_bool
                   http-request set-metadata mock_key %[urlp(param1)]
+                  http-request set-header metadata_header %[metadata(mock_key)]
+                  http-request set-header mock_key value_to_be_fetched
+                  http-request set-metadata mock_key %[hdr(mock_key,-1)]
+                  http-request set-header metadata_value %[metadata(mock_key)]
           - name: envoy.filters.http.router
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/header-rewrite-filter/header_processor.h
+++ b/header-rewrite-filter/header_processor.h
@@ -41,6 +41,7 @@ private:
   Utility::FunctionType getFunctionType(absl::string_view function_expression);
   std::tuple<absl::Status, std::string> getUrlp(Http::RequestOrResponseHeaderMap& headers, absl::string_view param);
   std::tuple<absl::Status, std::string> getHeaderValue(Http::RequestOrResponseHeaderMap& headers, absl::string_view key, int position);
+  std::tuple<absl::Status, std::string> getDynamicMetadata(Http::RequestOrResponseHeaderMap& headers, Envoy::StreamInfo::StreamInfo* streamInfo, absl::string_view key);
 
   Utility::FunctionType function_type_;
   std::string function_argument_;

--- a/header-rewrite-filter/utility.cc
+++ b/header-rewrite-filter/utility.cc
@@ -53,6 +53,8 @@ FunctionType StringToFunctionType(absl::string_view function) {
         return FunctionType::GetHdr;
     } else if (function.compare(DYNAMIC_VALUE_URL_PARAM) == 0) {
         return FunctionType::Urlp;
+    } else if (function.compare(DYNAMIC_VALUE_METADATA) == 0) {
+        return FunctionType::GetMetadata;
     } else {
         return FunctionType::InvalidFunctionType;
     }

--- a/header-rewrite-filter/utility.h
+++ b/header-rewrite-filter/utility.h
@@ -46,6 +46,7 @@ constexpr absl::string_view BOOLEAN_NOT = "not";
 
 constexpr absl::string_view DYNAMIC_VALUE_HDR = "hdr";
 constexpr absl::string_view DYNAMIC_VALUE_URL_PARAM = "urlp";
+constexpr absl::string_view DYNAMIC_VALUE_METADATA = "metadata";
 
 enum class OperationType : int {
   SetHeader,
@@ -74,6 +75,7 @@ enum class BooleanOperatorType : int {
 enum class FunctionType : int {
   GetHdr,
   Urlp,
+  GetMetadata,
   Static,
   InvalidFunctionType
 };


### PR DESCRIPTION
## Description
This PR implements being able to fetch from the header rewrite filter's dynamic metadata and use the resulting value in header rewrite operations. (Also cleaned up some code.)

## Testing
- Tested locally
Envoy config:
```
http-request set-header mock_key value_to_be_fetched
http-request set-metadata mock_key %[hdr(mock_key,-1)]
http-request set-header metadata_value %[metadata(mock_key)]
```
The headers show up in the request:
```
mock_key: value_to_be_fetched
metadata_value: value_to_be_fetched
```
- Added unit tests
```
==================== Test output for //header-rewrite-filter:header_processor_test:
[==========] Running 6 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 6 tests from ProcessorTest
[ RUN      ] ProcessorTest.SetHeaderProcessorTest
[       OK ] ProcessorTest.SetHeaderProcessorTest (2 ms)
[ RUN      ] ProcessorTest.AppendHeaderProcessorTest
[       OK ] ProcessorTest.AppendHeaderProcessorTest (0 ms)
[ RUN      ] ProcessorTest.SetPathProcessorTest
[       OK ] ProcessorTest.SetPathProcessorTest (0 ms)
[ RUN      ] ProcessorTest.SetBoolProcessorTest
[       OK ] ProcessorTest.SetBoolProcessorTest (1 ms)
[ RUN      ] ProcessorTest.ConditionProcessorTest
[       OK ] ProcessorTest.ConditionProcessorTest (0 ms)
[ RUN      ] ProcessorTest.DynamicMetadataTest
[       OK ] ProcessorTest.DynamicMetadataTest (9 ms)
[----------] 6 tests from ProcessorTest (14 ms total)

[----------] Global test environment tear-down
[==========] 6 tests from 1 test suite ran. (14 ms total)
[  PASSED  ] 6 tests.
================================================================================
Target //header-rewrite-filter:header_processor_test up-to-date:
  bazel-bin/header-rewrite-filter/header_processor_test
INFO: Elapsed time: 33.241s, Critical Path: 32.79s
INFO: 4 processes: 1 internal, 3 linux-sandbox.
INFO: Build completed successfully, 4 total actions

Executed 1 out of 1 test: 1 test passes.
```