### PR TITLE
made conditionals unambiguous

### DIFF
--- a/header-rewrite-filter/header_processor.h
+++ b/header-rewrite-filter/header_processor.h
@@ -67,6 +67,12 @@ public:
   virtual ~ConditionProcessor() {}
   virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start);
   virtual std::tuple<absl::Status, bool> executeOperation(Http::RequestOrResponseHeaderMap& headers, Envoy::StreamInfo::StreamInfo* streamInfo); // return status and condition result
+  virtual std::tuple<absl::Status, bool> executeOperationRecursively(Http::RequestOrResponseHeaderMap& headers, Envoy::StreamInfo::StreamInfo* streamInfo,
+    std::vector<Utility::BooleanOperatorType>::iterator operators_start, std::vector<Utility::BooleanOperatorType>::iterator operators_end,
+    std::vector<std::tuple<std::string, bool>>::iterator operands_start, std::vector<std::tuple<std::string, bool>>::iterator operands_end);
+  virtual std::tuple<absl::Status, bool> executeOperationLinearly(Http::RequestOrResponseHeaderMap& headers, Envoy::StreamInfo::StreamInfo* streamInfo, 
+    std::vector<Utility::BooleanOperatorType>::iterator operators_start, std::vector<Utility::BooleanOperatorType>::iterator operators_end,
+    std::vector<std::tuple<std::string, bool>>::iterator operands_start, std::vector<std::tuple<std::string, bool>>::iterator operands_end);
 
 private:
   std::vector<Utility::BooleanOperatorType> operators_;

--- a/header-rewrite-filter/header_processor_test.cc
+++ b/header-rewrite-filter/header_processor_test.cc
@@ -232,13 +232,17 @@ TEST_F(ProcessorTest, ConditionProcessorTest) {
         "not mock_false_bool",
         "mock_true_bool and mock_true_bool",
         "mock_true_bool or mock_false_bool",
-        "mock_true_bool or not mock_false_bool or mock_false_bool"
+        "mock_true_bool or not mock_false_bool or mock_false_bool",
+        "mock_true_bool or mock_false_bool and mock_false_bool",
+        "mock_true_bool or not mock_false_bool or not mock_true_bool and mock_true_bool or mock_false_bool and mock_false_bool or mock_true_bool"
     };
 
     std::vector<absl::string_view> false_condition_test_cases = {
         "mock_false_bool",
         "not mock_true_bool",
-        "mock_true_bool or mock_false_bool and mock_false_bool"
+        "mock_false_bool and not mock_true_bool or not mock_true_bool or mock_true_bool and mock_false_bool or mock_false_bool or not mock_true_bool",
+        "not mock_true_bool or mock_true_bool and not mock_true_bool",
+        "mock_true_bool and mock_true_bool and not mock_false_bool and mock_false_bool or mock_true_bool and mock_false_bool and mock_true_bool or not mock_true_bool"
     };
 
     std::vector<absl::string_view> invalid_parsing_test_cases = {

--- a/header-rewrite-filter/utility.cc
+++ b/header-rewrite-filter/utility.cc
@@ -64,6 +64,10 @@ bool isOperator(BooleanOperatorType operator_type) {
     return (operator_type == BooleanOperatorType::And || operator_type == BooleanOperatorType::Or || operator_type == BooleanOperatorType::Not);
 }
 
+bool isOR(BooleanOperatorType operator_type) {
+    return operator_type == BooleanOperatorType::Or;
+}
+
 bool isBinaryOperator(BooleanOperatorType operator_type) {
     return (operator_type == BooleanOperatorType::And || operator_type == BooleanOperatorType::Or);
 }

--- a/header-rewrite-filter/utility.h
+++ b/header-rewrite-filter/utility.h
@@ -86,6 +86,7 @@ BooleanOperatorType StringToBooleanOperatorType(absl::string_view bool_operator)
 FunctionType StringToFunctionType(absl::string_view function);
 
 bool isOperator(BooleanOperatorType operator_type);
+bool isOR(BooleanOperatorType operator_type);
 bool isBinaryOperator(BooleanOperatorType operator_type);
 bool evaluateExpression(bool operand1, BooleanOperatorType operator_val, bool operand2);
 


### PR DESCRIPTION
## Description
Established a strict order of operations when executing conditionals such that ORs are always executed before ANDs. This makes it so that an expression is evaluated unambiguously (before it would evaluate left to right). See [this doc](https://docs.google.com/document/d/1ZUg-_Z7sOKCSbDJXuJ0wuZP2lYX96lXIs7PkCNFy0UE/edit?usp=sharing) for more details.

JIRA=[EDGEBE-471](https://datadoghq.atlassian.net/browse/EDGEBE-471)

## Testing
Updated and reran unit tests.

[EDGEBE-471]: https://datadoghq.atlassian.net/browse/EDGEBE-471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ