### PR TITLE
code cleanup

### DIFF
--- a/header-rewrite-filter/envoy-sample-config.yaml
+++ b/header-rewrite-filter/envoy-sample-config.yaml
@@ -44,8 +44,7 @@ static_resources:
           - name: sample
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.HeaderRewrite
-              key: header-processing
-              val: |
+              config: |
                   http-request set-bool true_bool %[hdr(mock_header,-1)] -m str mock_val
                   http-response set-bool false_bool %[hdr(transfer-encoding)] -m sub not_chunked
                   http-request set-bool another_true_bool %[urlp(mock_param)] -m found

--- a/header-rewrite-filter/header_processor.h
+++ b/header-rewrite-filter/header_processor.h
@@ -1,5 +1,4 @@
 #pragma once
-
 #include "utility.h"
 
 #include "source/common/common/utility.h"
@@ -22,7 +21,7 @@ class Processor {
 public:
   Processor(SetBoolProcessorMapSharedPtr bool_processors, bool isRequest) : bool_processors_(bool_processors), is_request_(isRequest)  { }
   virtual ~Processor() {}
-  virtual absl::Status parseOperation(std::vector<absl::string_view>& operation_expression, std::vector<absl::string_view>::iterator start) { return absl::OkStatus(); }
+  virtual absl::Status parseOperation([[maybe_unused]] std::vector<absl::string_view>& operation_expression, [[maybe_unused]] std::vector<absl::string_view>::iterator start) { return absl::OkStatus(); }
 
 protected:
   SetBoolProcessorMapSharedPtr bool_processors_;
@@ -37,11 +36,12 @@ public:
   std::tuple<absl::Status, std::string> executeOperation(Http::RequestOrResponseHeaderMap& headers, Envoy::StreamInfo::StreamInfo* streamInfo);
 
 private:
+  using Processor::parseOperation;
   std::tuple<absl::Status, std::string> getFunctionArgument(absl::string_view function_expression);
   Utility::FunctionType getFunctionType(absl::string_view function_expression);
   std::tuple<absl::Status, std::string> getUrlp(Http::RequestOrResponseHeaderMap& headers, absl::string_view param);
   std::tuple<absl::Status, std::string> getHeaderValue(Http::RequestOrResponseHeaderMap& headers, absl::string_view key, int position);
-  std::tuple<absl::Status, std::string> getDynamicMetadata(Http::RequestOrResponseHeaderMap& headers, Envoy::StreamInfo::StreamInfo* streamInfo, absl::string_view key);
+  std::tuple<absl::Status, std::string> getDynamicMetadata(Envoy::StreamInfo::StreamInfo* streamInfo, absl::string_view key);
 
   Utility::FunctionType function_type_;
   std::string function_argument_;
@@ -57,7 +57,7 @@ public:
   virtual std::tuple<absl::Status, bool> executeOperation(Http::RequestOrResponseHeaderMap& headers, Envoy::StreamInfo::StreamInfo* streamInfo, bool negate); // return status and bool result
 
 private:
-  std::function<bool(std::string)> matcher_ = [](std::string str) -> bool { return false; };
+  std::function<bool(std::string)> matcher_ = []([[maybe_unused]] std::string str) -> bool { return false; };
   DynamicFunctionProcessorSharedPtr dynamic_function_processor_ = nullptr;
 };
 
@@ -85,7 +85,7 @@ class HeaderProcessor : public Processor {
 public:
   HeaderProcessor(SetBoolProcessorMapSharedPtr bool_processors, bool isRequest) : Processor(bool_processors, isRequest) {}
   virtual ~HeaderProcessor() {}
-  virtual absl::Status executeOperation(Http::RequestOrResponseHeaderMap& headers, Envoy::StreamInfo::StreamInfo* streamInfo) { return absl::OkStatus(); }
+  virtual absl::Status executeOperation([[maybe_unused]] Http::RequestOrResponseHeaderMap& headers, [[maybe_unused]] Envoy::StreamInfo::StreamInfo* streamInfo) { return absl::OkStatus(); }
   virtual std::tuple<absl::Status, bool> evaluateCondition(Http::RequestOrResponseHeaderMap& headers, Envoy::StreamInfo::StreamInfo* streamInfo); // return status and condition result
   void setConditionProcessor(ConditionProcessorSharedPtr condition_processor) { condition_processor_ = condition_processor; }
   ConditionProcessorSharedPtr getConditionProcessor() { return condition_processor_; }

--- a/header-rewrite-filter/header_rewrite.cc
+++ b/header-rewrite-filter/header_rewrite.cc
@@ -21,7 +21,7 @@ void fail(absl::string_view msg) {
 
 HttpHeaderRewriteFilterConfig::HttpHeaderRewriteFilterConfig(
     const envoy::extensions::filters::http::HeaderRewrite& proto_config)
-    : key_(proto_config.key()), val_(proto_config.val()) {}
+    : config_(proto_config.config()) {}
 
 HttpHeaderRewriteFilter::HttpHeaderRewriteFilter(HttpHeaderRewriteFilterConfigSharedPtr config)
     : config_(config) {
@@ -30,7 +30,7 @@ HttpHeaderRewriteFilter::HttpHeaderRewriteFilter(HttpHeaderRewriteFilterConfigSh
   request_set_bool_processors_ = std::make_shared<std::unordered_map<std::string, SetBoolProcessorSharedPtr>>();
   response_set_bool_processors_ = std::make_shared<std::unordered_map<std::string, SetBoolProcessorSharedPtr>>();
   
-  const std::string header_config = headerValue();
+  const std::string header_config = headerConfig();
 
   // split by operation (newline delimited config)
   auto operations = StringUtil::splitToken(header_config, "\n", false, true);
@@ -132,12 +132,8 @@ HttpHeaderRewriteFilter::HttpHeaderRewriteFilter(HttpHeaderRewriteFilterConfigSh
   }
 }
 
-const Http::LowerCaseString HttpHeaderRewriteFilter::headerKey() const {
-  return Http::LowerCaseString(config_->key());
-}
-
-const std::string HttpHeaderRewriteFilter::headerValue() const {
-  return config_->val();
+const std::string HttpHeaderRewriteFilter::headerConfig() const {
+  return config_->config();
 }
 
 Http::FilterHeadersStatus HttpHeaderRewriteFilter::decodeHeaders(Http::RequestHeaderMap& headers, bool) {

--- a/header-rewrite-filter/header_rewrite.h
+++ b/header-rewrite-filter/header_rewrite.h
@@ -17,12 +17,10 @@ class HttpHeaderRewriteFilterConfig {
 public:
   HttpHeaderRewriteFilterConfig(const envoy::extensions::filters::http::HeaderRewrite& proto_config);
 
-  const std::string& key() const { return key_; }
-  const std::string& val() const { return val_; }
+  const std::string& config() const { return config_; }
 
 private:
-  const std::string key_;
-  const std::string val_;
+  const std::string config_;
 };
 
 using HttpHeaderRewriteFilterConfigSharedPtr = std::shared_ptr<HttpHeaderRewriteFilterConfig>;
@@ -54,8 +52,7 @@ private:
   SetBoolProcessorMapSharedPtr request_set_bool_processors_;
   SetBoolProcessorMapSharedPtr response_set_bool_processors_;
 
-  const Http::LowerCaseString headerKey() const;
-  const std::string headerValue() const;
+  const std::string headerConfig() const;
   void setError() { error_ = true; }
   bool getError() const { return error_; };
 };

--- a/header-rewrite-filter/header_rewrite.proto
+++ b/header-rewrite-filter/header_rewrite.proto
@@ -5,6 +5,5 @@ package envoy.extensions.filters.http;
 import "validate/validate.proto";
 
 message HeaderRewrite {
-    string key = 1 [(validate.rules).string.min_len = 1];
-    string val = 2 [(validate.rules).string.min_len = 1];
+    string config = 1 [(validate.rules).string.min_len = 1];
 }

--- a/header-rewrite-filter/header_rewrite_config.cc
+++ b/header-rewrite-filter/header_rewrite_config.cc
@@ -30,7 +30,7 @@ public:
     return ProtobufTypes::MessagePtr{new envoy::extensions::filters::http::HeaderRewrite()};
   }
 
-  std::string name() const override { return "sample"; }
+  std::string name() const override { return "envoy.header_rewrite"; }
 
 private:
   Http::FilterFactoryCb createFilter(const envoy::extensions::filters::http::HeaderRewrite& proto_config, FactoryContext&) {

--- a/header-rewrite-filter/header_rewrite_integration_test.cc
+++ b/header-rewrite-filter/header_rewrite_integration_test.cc
@@ -25,8 +25,8 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, HttpFilterHeaderRewriteIntegrationTest,
 
 // test adding a new header key-value pair
 TEST_P(HttpFilterHeaderRewriteIntegrationTest, SetHeader) {
-  SetUp("{ name: sample, typed_config: { \"@type\": type.googleapis.com/envoy.extensions.filters.http.HeaderRewrite, key: header-processing,"
-    "val: http-request set-header sample_key sample_value } }");
+  SetUp("{ name: sample, typed_config: { \"@type\": type.googleapis.com/envoy.extensions.filters.http.HeaderRewrite,"
+    "config: http-request set-header sample_key sample_value } }");
   Http::TestRequestHeaderMapImpl headers{
       {":method", "GET"}, {":path", "/"}, {":authority", "host"}};
   Http::TestRequestHeaderMapImpl response_headers{
@@ -53,8 +53,8 @@ TEST_P(HttpFilterHeaderRewriteIntegrationTest, SetHeader) {
 
 // test adding a new value to an already existing header
 TEST_P(HttpFilterHeaderRewriteIntegrationTest, AppendHeader) {
-  SetUp("{ name: sample, typed_config: { \"@type\": type.googleapis.com/envoy.extensions.filters.http.HeaderRewrite, key: header-processing,"
-    "val: http-request append-header sample_key sample_value2 sample_value3 } }");
+  SetUp("{ name: sample, typed_config: { \"@type\": type.googleapis.com/envoy.extensions.filters.http.HeaderRewrite,"
+    "config: http-request append-header sample_key sample_value2 sample_value3 } }");
   Http::TestRequestHeaderMapImpl headers{
       {":method", "GET"}, {":path", "/"}, {":authority", "host"}, {"sample_key", "sample_value1"}};
   Http::TestRequestHeaderMapImpl response_headers{
@@ -75,43 +75,6 @@ TEST_P(HttpFilterHeaderRewriteIntegrationTest, AppendHeader) {
   EXPECT_EQ(
       "sample_value1,sample_value2,sample_value3",
       request_stream->headers().get(Http::LowerCaseString("sample_key"))[0]->value().getStringView());
-
-  codec_client->close();
-}
-
-// test set-metadata operation
-TEST_P(HttpFilterHeaderRewriteIntegrationTest, SetMetadata) {
-  SetUp("{ name: sample, typed_config: { \"@type\": type.googleapis.com/envoy.extensions.filters.http.HeaderRewrite, key: header-processing,"
-    "\"val\": \"http-request set-metadata mock_key %[hdr(mock_header)]\" } }");
-  Http::TestRequestHeaderMapImpl headers{
-      {":method", "GET"}, {":path", "/"}, {":authority", "host"}, {"mock_header", "mock_value"}};
-  Http::TestRequestHeaderMapImpl response_headers{
-      {":status", "200"}};
-
-  IntegrationCodecClientPtr codec_client;
-  FakeHttpConnectionPtr fake_upstream_connection;
-  FakeStreamPtr request_stream;
-
-  codec_client = makeHttpConnection(lookupPort("http"));
-  auto response = codec_client->makeHeaderOnlyRequest(headers);
-  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection));
-  ASSERT_TRUE(fake_upstream_connection->waitForNewStream(*dispatcher_, request_stream));
-  ASSERT_TRUE(request_stream->waitForEndStream(*dispatcher_));
-  request_stream->encodeHeaders(response_headers, true);
-  ASSERT_TRUE(response->waitForEndStream());
-
-  const auto filter_metadata_map = request_stream->streamInfo().dynamicMetadata().filter_metadata();
-  
-  // verify metadata for the filter exists
-  EXPECT_TRUE(filter_metadata_map.find("envoy.extensions.filters.http.HeaderRewrite") != filter_metadata_map.end());
-
-  const auto metadata_map = filter_metadata_map.find("envoy.extensions.filters.http.HeaderRewrite")->second.fields();
-
-  // verify metadata with the expected key exists
-  EXPECT_TRUE(metadata_map.find("mock_key") != metadata_map.end());
-
-  // verify expected value of metadata
-  EXPECT_EQ("mock_value", metadata_map.find("mock_key")->second.string_value());
 
   codec_client->close();
 }


### PR DESCRIPTION
## Description
Summary of changes:
- Dealt with all build warnings -- this is important because the actual envoy bazel configuration treats warnings as errors
- Verified that no status/result variables were being reused as mentioned [here](https://github.com/DataDog/envoy-filter-example/pull/35#discussion_r1295966503)
- Changed error codes to be more descriptive
- Used `std::move` alongside `std::string` whenever possible to avoid unnecessary copies
- Removed unneeded protobuf field
- Renamed filter from `sample` to `header_rewrite`
- Verified behavior for edge cases, eg. extra whitespace
- Added checks to verify that no `operation_expression` is being accessed out of bounds
- Made variables `const` whenever possible
- Removed metadata integration test (see #40)

JIRA=[EDGEBE-467](https://datadoghq.atlassian.net/browse/EDGEBE-467)

## Testing
Added to and re-ran unit tests

[EDGEBE-467]: https://datadoghq.atlassian.net/browse/EDGEBE-467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ