### PR TITLE
make both arguments to set bool dynamic

### DIFF
--- a/header-rewrite-filter/header_processor.h
+++ b/header-rewrite-filter/header_processor.h
@@ -57,8 +57,10 @@ public:
   virtual std::tuple<absl::Status, bool> executeOperation(Http::RequestOrResponseHeaderMap& headers, Envoy::StreamInfo::StreamInfo* streamInfo, bool negate); // return status and bool result
 
 private:
-  std::function<bool(std::string)> matcher_ = []([[maybe_unused]] std::string str) -> bool { return false; };
-  DynamicFunctionProcessorSharedPtr dynamic_function_processor_ = nullptr;
+  absl::Status stringToCompareSetup(absl::string_view string_to_compare);
+  std::function<bool(const std::string, const std::string)> matcher_ = []([[maybe_unused]] const std::string& source, [[maybe_unused]] const std::string& string_to_compare) -> bool { return false; };
+  DynamicFunctionProcessorSharedPtr source_processor_ = nullptr;
+  DynamicFunctionProcessorSharedPtr string_to_compare_function_processor_ = nullptr;
 };
 
 class ConditionProcessor : public Processor {

--- a/header-rewrite-filter/header_processor_test.cc
+++ b/header-rewrite-filter/header_processor_test.cc
@@ -139,7 +139,8 @@ TEST_F(ProcessorTest, SetBoolProcessorTest) {
         "http-request set-bool mock_bool %[hdr(mock_header1,-1)] -m str mock_value3", // exact, hdr 2 arg
         "http-request set-bool mock_bool %[hdr(mock_header1,0)] -m str mock_value1", // exact, hdr 2 arg
         "http-request set-bool mock_bool %[hdr(mock_header1,-3)] -m str mock_value1", // exact, hdr 2 arg
-        "http-request set-bool mock_bool %[hdr(mock_header3)] -m str []", // exact
+        "http-request set-bool mock_bool %[hdr(mock_header1)] -m str %[hdr(mock_header3)]", // exact, hdr 2 arg, both dynamic
+        "http-request set-bool mock_bool %[hdr(mock_header3,0)] -m str []", // exact
         "http-request set-bool mock_bool %[hdr(mock_header2)] -m beg mo", // prefix
         "http-request set-bool mock_bool %[urlp(param1)] -m beg so", // prefix, urlp
         "http-request set-bool mock_bool %[hdr(mock_header2)] -m sub lue", // substring
@@ -170,7 +171,7 @@ TEST_F(ProcessorTest, SetBoolProcessorTest) {
         Http::TestRequestHeaderMapImpl headers{
             {":method", "GET"}, {":path", "/?param1=something&param2=2"}, {":authority", "host"}, 
             {"mock_header1", "mock_value1,mock_value2,mock_value3"}, {"mock_header2", "mock_value"},
-            {"mock_header3", "[]"}};
+            {"mock_header3", "[],mock_value3"}};
         absl::Status status = set_bool_processor.parseOperation(tokens, (tokens.begin() + 2));
         EXPECT_TRUE(status == absl::OkStatus());
         EXPECT_EQ(status.message(), "");


### PR DESCRIPTION
## Description
The right side of a boolean expression in a `set-bool` operation was still hard-coded as static. This PR allows it to be interpreted as a static or dynamic value.

Ex:
`http-request set-bool mock_bool %[hdr(mock_header1)] -m str %[hdr(mock_header3)]` -- both dynamic
`http-request set-bool mock_bool %[hdr(mock_header1)] -m str static_value` -- one dynamic, one static

## Testing
- Added to unit tests and reran them.
- End to end test
Envoy config:
```
http-request set-bool mock_bool %[hdr(mock_header1)] -m str %[hdr(mock_header3)]
http-request set-header mock_header1 mock_val
http-request set-header mock_header3 random_val
http-request append-header mock_header3 mock_val
http-request set-header should_be_set to_a_value if mock_bool
```
Request headers:
```
mock_header1: mock_val
mock_header3: random_val,mock_val
should_be_set: to_a_value
```