### PR TITLE
tweak metadata operation, fix dynamic metadata unit tests

### DIFF
--- a/header-rewrite-filter/BUILD
+++ b/header-rewrite-filter/BUILD
@@ -53,6 +53,7 @@ envoy_cc_library(
         ":pkg_cc_proto",
         ":header_rewrite_utils_lib",
         "@envoy//source/common/common:utility_lib",
+        "@envoy//source/common/config:metadata_lib",
         "@envoy//source/common/http:utility_lib",
         "@envoy//source/common/common:minimal_logger_lib",
         "@envoy//source/extensions/filters/http/common:pass_through_filter_lib",
@@ -88,6 +89,7 @@ envoy_cc_test(
     repository = "@envoy",
     deps = [
         ":header_rewrite_processor_lib",
-         "@envoy//test/integration:http_integration_lib",
+        "@envoy//test/integration:http_integration_lib",
+        "@envoy//source/common/config:metadata_lib"
     ]
 )


### PR DESCRIPTION
## Description
This PR modifies the way dynamic metadata is set and accessed from within the processors for the purpose of verifying that everything works in the unit tests.

- Changes to setting metadata
Sets the metadata value within a protobuf struct rather than a string to stay consistent with the way Envoy works with the metadata. (See [this example](https://github.com/envoyproxy/envoy/blob/f44887ff8a412fd8ef27afa38d359754e5157019/test/common/config/metadata_test.cc#L31-L42).)
- Changes to getting metadata
Uses a convenient Envoy API to get metadata, abstracting away most of the logic. (See [API](https://github.com/envoyproxy/envoy/blob/93c92240e09add0548dbbfa6b9a463644d50d84c/source/common/config/metadata.cc#L25).)
- Changes to unit tests
Added all necessary mock calls to `StreamInfo` to connect the mock `dynamic_metadata` object to the processors when unit testing. 

Note: The integration test was removed because the combination of manual end-to-end testing and thorough unit tests is sufficient -- from looking at the Envoy source code, other filters that access or modify dynamic metadata rely solely on unit testing.